### PR TITLE
Fix tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.log*
 node_modules
 dist
+*package-lock.json

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,8 +71,8 @@ gulp.task('dist:js', () => opts.paths.js ? [].concat(opts.paths.js).map(
 			{
 				entry: jsPath,
 				format: opts.jsModuleFormat,
-				moduleName: opts.jsModuleName,
-				sourceMap: true
+				name: opts.jsModuleName,
+				sourcemap: true
 			},
 			opts.rollupConfig,
 			{


### PR DESCRIPTION
Looks like rollup made some changes to their property names in between versions, here. 

`sourceMap => sourcemap`
`moduleName => name`

