### PR TITLE
reset elements calcite applies general styles to

### DIFF
--- a/src/footer/css/footer-social.pcss
+++ b/src/footer/css/footer-social.pcss
@@ -30,7 +30,7 @@
 	}
 }
 
-.esri-footer-social-item {
+li.esri-footer-social-item {
 	margin-block-start: var(--footer-social-gutter);
 
 	@media (--gfoot-s) {

--- a/src/footer/css/footer.pcss
+++ b/src/footer/css/footer.pcss
@@ -15,6 +15,10 @@
 		box-sizing: border-box;
 	}
 
+	& ul, & li {
+		margin: 0;
+	}
+
 	@media (--gfoot-sm) {
 		min-height: 600px;
 	}

--- a/src/header/css/header.pcss
+++ b/src/header/css/header.pcss
@@ -31,6 +31,14 @@
 	&, & * {
 		box-sizing: border-box;
 	}
+
+	& ul, & li, & label {
+		margin: 0;
+	}
+
+	& input {
+		height: initial
+	}
 }
 
 /* Global Header: Canvas


### PR DESCRIPTION
calcite-web applies styles to `ul`, `li`, `input` and `label` elements which interfere with the look of the global-nav elements. Applying a reset for these fixes that problem.

One style required higher specificity to work with these resets. All other styles seem to work as designed.

applies to issues #87 and #13