### PR TITLE
Adjusted listen for events example to match current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The global nav dispatches custom events to each of its modules (Header and Foote
 ```js
 // You can Listen for events on the element generated from the create method
 globalNav.create(yourGlobalNavStructure);
-var esriHeader = $('.esri-header-barrier')[0];
+var esriHeader = document.querySelector('.esri-header-barrier');
 esriHeader.addEventListener("header:click:search", function () { ... });
 ```
 


### PR DESCRIPTION
Two adjustments, both based on the fact that the create() function does not return a handle to the global nav object.

* Removed the `return` from the `init()` function in the "Example: Import the new AMD Module for use within a Dijit" section
* Changed "Listening for Events" to acquire an object that can be used to listen for events

The latter uses jQuery at this time.