### PR TITLE
Fix domose reference path so that it can build properly

### DIFF
--- a/src/header/js/header-apps.js
+++ b/src/header/js/header-apps.js
@@ -1,6 +1,6 @@
 import {$assign as $, $dispatch, $replaceAll, $renderSvgOrImg} from '../../shared/js/shared';
 import Sortable from 'sortablejs';
-import {$remove} from 'domose';
+import {$remove} from '../../shared/js/domose';
 
 /* Apps
 /* ========================================================================== */


### PR DESCRIPTION
The pathless reference to the domose lib can't be resolved by the build script and it is included as an external dependency. This works in the demo apps because of where domose.js lives, but fails when the built files are included in other projects.