### PR TITLE
Allow internationalized social links, fix security issue 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/*
 !dist/esri-global-nav.js
 !dist/esri-global-nav.css
 !dist/img/
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 - Add `platform` property as a fallback for social media classes (#134)
 - Use `rel=noopener` on social links
+- When only search is used, divider is now hidden (#200)
 
 ## 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 - Add `platform` property as a fallback for social media classes (#134)
+- Use `rel=noopener` on social links
 
 ## 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.2
+
+### Fixed
+- Add `platform` property as a fallback for social media classes (#134)
+
 ## 1.1.1
 
 ### Fixed

--- a/gulp-tasks/banner.js
+++ b/gulp-tasks/banner.js
@@ -1,0 +1,16 @@
+const pkg = require('../package.json');
+module.exports = `
+/**
+ * Global Nav - A centralized component for Esri's global navigation
+ * @version v${pkg.version}
+ * @link https://github.com/Esri/global-nav
+ * @copyright ${(new Date()).getFullYear()} Esri
+ * @license
+ * All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
+ *
+ * This material is licensed for use under the Esri Master License Agreement (MLA), and is bound by the terms of that agreement.
+ * You may redistribute and use this code without modification, provided you adhere to the terms of the MLA and include this copyright notice.
+ *
+ * See use restrictions at http://www.esri.com/legal/pdfs/mla_e204_e300/english
+ */
+`

--- a/gulp-tasks/compile-js.js
+++ b/gulp-tasks/compile-js.js
@@ -14,7 +14,8 @@ const babel_preset_env = require('babel-preset-env');
 const source = require('vinyl-source-stream');
 const sourcemaps = require('gulp-sourcemaps');
 const size = require('gulp-size');
-
+const add_banner = require('gulp-banner');
+const banner = require('./banner');
 const pkg = require('../package.json');
 
 function compileJs() {
@@ -60,6 +61,9 @@ function compileJsFile({rootJs, saveAs}) {
 	})).pipe(
 		buffer()
 	).pipe(
+		add_banner(banner)
+	)
+	.pipe(
 		sourcemaps.init({
 			loadMaps: true
 		})

--- a/gulp-tasks/compile-postcss.js
+++ b/gulp-tasks/compile-postcss.js
@@ -4,7 +4,8 @@ const sourcemaps = require('gulp-sourcemaps');
 const postcss = require('gulp-postcss');
 const cssnano = require('gulp-cssnano');
 const ext = require('gulp-ext');
-
+const add_banner = require('gulp-banner');
+const banner = require('./banner');
 const pkg = require('../package.json');
 
 function compilePostCss() {
@@ -46,6 +47,7 @@ function compilePostCss() {
 		]))
 		.pipe(cssnano())
 		.pipe(ext.replace('css','pcss'))
+		.pipe(add_banner(banner))
 		.pipe(sourcemaps.write('./'))
 		.pipe(gulp.dest(pkg.gulp_config.build_path))
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gh-pages": "^1.0.0",
     "gh-release": "^3.1.1",
     "gulp": "^3.9.1",
+    "gulp-banner": "^0.1.3",
     "gulp-cssnano": "^2.1.2",
     "gulp-eslint": "^4.0.0",
     "gulp-ext": "^1.0.0",

--- a/src/footer/js/footer-social.js
+++ b/src/footer/js/footer-social.js
@@ -12,7 +12,8 @@ export default (data, prefix) => {
 					class: `${prefix}-social-item ${prefix}-social-link -${platform}`,
 					href: item.href,
 					aria: {label: item.label},
-					target: '_blank'
+					target: '_blank',
+					rel: 'noopener'
 				},
 				$renderSvgOrImg({imgDef: item.image.path, imgClass: `${prefix}-social-image`, alt: '', imgWidth: 30, imgHeight:30, viewBox : item.image.viewBox})
 			));

--- a/src/footer/js/footer-social.js
+++ b/src/footer/js/footer-social.js
@@ -5,10 +5,11 @@ export default (data, prefix) => {
 
 
 	data.menu.forEach((item) => {
+		const platform = item.platform || item.label.toLowerCase().replace(' ','-');
 		$($socialIcons,
 			$('a',
 				{
-					class: `${prefix}-social-item ${prefix}-social-link -${item.label.toLowerCase().replace(' ','-')}`,
+					class: `${prefix}-social-item ${prefix}-social-link -${platform}`,
 					href: item.href,
 					aria: {label: item.label},
 					target: '_blank'

--- a/src/header/css/header-client.pcss
+++ b/src/header/css/header-client.pcss
@@ -14,6 +14,10 @@
 	}
 }
 
+.esri-header-lineBreak-hidden {
+	display: none;
+}
+
 .esri-header-client {
 	display: flex;
 	flex-grow: 0;

--- a/src/header/js/header.js
+++ b/src/header/js/header.js
@@ -113,6 +113,10 @@ export default (data) => {
 			$dispatch($notifications, 'header:update:notifications', detail.notifications);
 		}
 
+		if (!detail.notifications && !detail.apps && !detail.account) {
+			$lineBreak.classList.add('esri-header-lineBreak-hidden');
+		}
+
 		$header.ownerDocument.defaultView.addEventListener('keydown', ({keyCode}) => {
 			if (27 === keyCode) {
 				$dispatch($header, 'header:menu:close');

--- a/src/home.js
+++ b/src/home.js
@@ -338,6 +338,7 @@ document.addEventListener("DOMContentLoaded", () => {
 				menu: [
 					{
 						label: 'Facebook',
+						platform: 'facebook',
 						href: 'https://www.facebook.com/esrigis',
 						image: {
 							viewBox: '0 0 38 38',
@@ -346,6 +347,7 @@ document.addEventListener("DOMContentLoaded", () => {
 					},
 					{
 						label: 'Twitter',
+						platform: 'twitter',
 						href: 'https://twitter.com/Esri',
 						image: {
 							viewBox: '0 0 512 512',
@@ -354,6 +356,7 @@ document.addEventListener("DOMContentLoaded", () => {
 					},
 					{
 						label: 'LinkedIn',
+						platform: 'linkedin',
 						href: 'https://www.linkedin.com/company/esri',
 						image: {
 							viewBox: '0 0 24 24',
@@ -362,6 +365,7 @@ document.addEventListener("DOMContentLoaded", () => {
 					},
 					{
 						label: 'Instagram',
+						platform: 'instagram',
 						href: 'https://www.instagram.com/esrigram/',
 						image: {
 							viewBox: '0 0 30 30',
@@ -370,6 +374,7 @@ document.addEventListener("DOMContentLoaded", () => {
 					},
 					{
 						label: 'YouTube',
+						platform: 'youtube',
 						href: 'https://www.youtube.com/user/esritv',
 						image: {
 							viewBox: '0 0 310 310',
@@ -378,6 +383,7 @@ document.addEventListener("DOMContentLoaded", () => {
 					},
 					{
 						label: 'GeoNet',
+						platform: 'geonet',
 						href: 'https://geonet.esri.com/',
 						image: {
 							viewBox: '7 7 16 16',

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
     <title>Esri Global Nav Demo Pages</title>
     <link rel="stylesheet" href="./esri-global-nav.css">
     <link rel="stylesheet" href="https://s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/1.0.1/css/calcite-web.min.css">
+    <link rel="stylesheet" href="./syntax.css">
 </head>
 <body>
     <a class="skip-to-content" href="#skip-to-content">Skip To Content</a>
@@ -43,7 +44,7 @@
 
                 <p>First, you need to import the global nav library into your page. The best way to do this will vary based on your toolchain and build process. For static html pages, you can simply add a link to the JS and CSS files:</p>
 
-<pre><code>&lt;!-- in the HEAD tag --&gt;
+<pre><code class="language-markup">&lt;!-- in the HEAD tag --&gt;
 &lt;link rel="stylesheet" href="./esri-global-nav.css"&gt;
 &lt;!-- before the end of BODY tag --&gt;
 &lt;script src="./path/to/esri-global-nav.js"&gt;&lt;/script&gt;
@@ -51,11 +52,11 @@
 
                 <p>If you're using a module system for your JS, the library can be imported via CommonJS:</p>
 
-<pre><code>var globalNav = require('esri-global-nav')</code></pre>
+<pre><code class="language-js">var globalNav = require('esri-global-nav')</code></pre>
 
                 <p>Or AMD (Dojo define syntax):</p>
 
-<pre><code>define([
+<pre><code class="language-js">define([
   "esri-global-nav/dist/esri-global-nav.js"
 ], function (globalNav) {
   return {
@@ -77,7 +78,7 @@
 
                 <p>The basic stucture of the options object would look something like this (abbreviated for clarity):</p>
 
-<pre><code>{
+<pre><code class="language-js">{
   header: {
     theme: 'web',
     brand: {
@@ -251,9 +252,9 @@
 };
 </code></pre>
 
-                <p>After you've defined the structure of your navigation, just call <code>globalNav.create</code> to start up your navigation, passing in the options and the containers like so:</p>
+                <p>After you've defined the structure of your navigation, just call <code class="language-js">globalNav.create</code> to start up your navigation, passing in the options and the containers like so:</p>
 
-<pre><code>esriGlobalNav.create({headerElm: '.esri-header-barrier', footerElm: '.esri-footer-barrier', menuData});</code></pre>
+<pre><code class="language-js">esriGlobalNav.create({headerElm: '.esri-header-barrier', footerElm: '.esri-footer-barrier', menuData});</code></pre>
 
                 <p>For a complete example, you can reference <a href="https://github.com/Esri/global-nav/blob/master/src/demo.js">the demo</a>.</p>
 
@@ -261,26 +262,26 @@
 
                 <p>The global nav dispatches custom events to each of its modules (Header and Footer).</p>
 
-<pre><code>globalNav.create(yourGlobalNavStructure);
+<pre><code class="language-js">globalNav.create(yourGlobalNavStructure);
 var esriHeader = document.querySelector('.esri-header-barrier');
 esriHeader.addEventListener("header:click:search", function () { ... });</code></pre>
 
                 <p>Important events:</p>
 
                 <ul>
-                    <li><code>header:click:account</code></li>
-                    <li><code>header:click:search</code></li>
-                    <li><code>header:click:signin</code></li>
-                    <li><code>header:click:signout</code></li>
-                    <li><code>header:click:switch</code></li>
-                    <li><code>header:menu:toggle</code></li>
+                    <li><code class="language-js">header:click:account</code></li>
+                    <li><code class="language-js">header:click:search</code></li>
+                    <li><code class="language-js">header:click:signin</code></li>
+                    <li><code class="language-js">header:click:signout</code></li>
+                    <li><code class="language-js">header:click:switch</code></li>
+                    <li><code class="language-js">header:menu:toggle</code></li>
                 </ul>
 
                 <h2 class="leader-2">Advanced</h2>
                 <h3>Opening Links in a New Tab</h3>
                 <p>Links, within a menu, can be configured to open in a new tab. As of now, this only works for links within dropdown submenus.</p>
 
-<pre><code>yourGlobalNavStructure = {
+<pre><code class="language-js">yourGlobalNavStructure = {
   theme: 'web',
   menus: [[
     {
@@ -294,7 +295,7 @@ esriHeader.addEventListener("header:click:search", function () { ... });</code><
                 <h3>Adding Data Attributes to Links</h3>
                 <p>Menu links can receive data attributes too. Here, we create a special page link that has an an attribute of "data-id" that's equal to "1" and "data-show-link" that's equal to "true". As of now, this only works for links within dropdown submenus</p>
 
-<pre><code>yourGlobalNavStructure = {
+<pre><code class="language-js">yourGlobalNavStructure = {
   theme: 'web',
   menus: [[
     {
@@ -310,7 +311,7 @@ esriHeader.addEventListener("header:click:search", function () { ... });</code><
 
               <h3>Always Display the Hamburger</h3>
 
-<pre><code>
+<pre><code class="language-js">
 header: {
   collapseMenus: [true, false]
 </code></pre>
@@ -318,7 +319,7 @@ header: {
               <h3>Using Inline Search</h3>
               <p>Inline search is a powerful way to supercharge the search experience for your users. It gives users the ability to view search results & suggestions in a dropdown without having to navigate away from their current content.</p>
 
-<pre><code>
+<pre><code class="language-js">
 //_______________________________________________________________________________
 // - To use inline search, set the parameter inline to true within the search object
 //-------------------------------------------------------------------------------
@@ -382,7 +383,7 @@ event.initCustomEvent('header:search:update:suggestions', true, true, {
               <h3>Configuring the App Launcher</h3>
               <p>To work with the standard set of apps from ArcGIS Online use the AGO Webworker Interface: <a href="https://github.com/ArcGIS/AGO-Webworker-Interface">https://github.com/ArcGIS/AGO-Webworker-Interface</a></p>
 
-<pre><code>
+<pre><code class="language-js">
 //_______________________________________________________________________________
 // - Before apps are loaded, we want to initialize the apps component with a loading state
 // -- Dispatch the event to update apps in the header
@@ -462,5 +463,6 @@ event.initCustomEvent("header:update:apps", true, true, {
     <div class="esri-footer-barrier"></div>
     <script src="./esri-global-nav.js"></script>
     <script src="./home.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.15.0/prism.min.js"></script>
 </body>
 </html>

--- a/src/syntax.css
+++ b/src/syntax.css
@@ -1,0 +1,48 @@
+.token.comment {
+  color: slategray;
+}
+
+.token.punctuation {
+  color: #999;
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant {
+  color: #905;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char {
+  color: #690;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+  color: #9a6e3a;
+  background: hsla(0, 0%, 100%, .5);
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+  color: #07a;
+}
+
+.token.function,
+.token.class-name {
+  color: #DD4A68;
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+  color: #e90;
+}


### PR DESCRIPTION
Now you can set the `platform` property of a social link to explicitly set the class name. I've left the curren functionality (computing the class via the `label`) for backwards compatibility. (#134)

Social links should have `rel=noopener` as they are opening with `target=_blank`. This prevents the next page from gaining access to the initial page (can be used for phishing).

also addresses #127

---

Adds a copyright banner to the built js and css files as well (#126)