### PR TITLE
Fix gulp tasks for build

### DIFF
--- a/gulp-tasks/compile-js.js
+++ b/gulp-tasks/compile-js.js
@@ -18,11 +18,14 @@ const add_banner = require('gulp-banner');
 const banner = require('./banner');
 const pkg = require('../package.json');
 
-function compileJs() {
+function compileJs(cb) {
 	compileJsFile({rootJs: `./${pkg.main}`, saveAs: `${pkg.gulp_config.build_name}.js`});
 	compileJsFile({rootJs: `./${pkg.gulp_config.src_path}/demo.js`, saveAs: 'demo.js'});
 	compileJsFile({rootJs: `./${pkg.gulp_config.src_path}/home.js`, saveAs: 'home.js'});
 	compileJsFile({rootJs: `./${pkg.gulp_config.src_path}/app-mode-demo.js`, saveAs: 'app-mode-demo.js'});
+	if (cb) {
+		cb();
+	}
 }
 
 function compileJsFile({rootJs, saveAs}) {
@@ -90,7 +93,7 @@ function compileJsFile({rootJs, saveAs}) {
 		);
 }
 
-gulp.task('compile-js', () => compileJs());
+gulp.task('compile-js', (cb) => compileJs(cb));
 
 gulp.task('watch-js', () => {
 	console.log('watching js...');

--- a/gulp-tasks/compile-js.js
+++ b/gulp-tasks/compile-js.js
@@ -93,7 +93,7 @@ function compileJsFile({rootJs, saveAs}) {
 		);
 }
 
-gulp.task('compile-js', (cb) => compileJs(cb));
+gulp.task('compile-js', compileJs);
 
 gulp.task('watch-js', () => {
 	console.log('watching js...');

--- a/gulp-tasks/copy-static-files.js
+++ b/gulp-tasks/copy-static-files.js
@@ -7,7 +7,7 @@ const pkg = require('../package.json');
 const staticGlob = ['html', 'css', 'json','jpg'].map((ext) => `${pkg.gulp_config.src_path}/**/*.${ext}`);
 
 function copyStaticFiles(staticPaths) {
-	gulp.src(staticPaths, {base: pkg.gulp_config.src_path})
+	return gulp.src(staticPaths, {base: pkg.gulp_config.src_path})
 		.pipe(logger({
 			before: 'Copying static files...',
 			after: 'Copying static files complete!',
@@ -18,7 +18,7 @@ function copyStaticFiles(staticPaths) {
 
 gulp.task('copy-static-files', () => {
 	console.log('copy-static-files');
-	copyStaticFiles(staticGlob);
+	return copyStaticFiles(staticGlob);
 });
 
 gulp.task('watch-static-files', () => {

--- a/gulp-tasks/es-lint.js
+++ b/gulp-tasks/es-lint.js
@@ -20,7 +20,7 @@ function lintJs(sourceFiles) {
 }
 
 gulp.task('es-lint', () => {
-    lintJs(`${pkg.gulp_config.src_path}/**/*.js`);
+    return lintJs(`${pkg.gulp_config.src_path}/**/*.js`);
 });
 
 gulp.task('watch-es-lint', () => {

--- a/gulp-tasks/optimize-images.js
+++ b/gulp-tasks/optimize-images.js
@@ -7,14 +7,14 @@ const pkg = require('../package.json');
 const svgs = `${pkg.gulp_config.src_path}/img/**/*.svg`;
 
 function optimizeImages() {
-	gulp.src(svgs)
+	return gulp.src(svgs)
 		.pipe(svgmin())
 		.pipe(gulp.dest(`${pkg.gulp_config.build_path}/img`));
 }
 
 gulp.task('optimize-images', () => {
 	console.log('optimizing images...');
-	optimizeImages();
+	return optimizeImages();
 });
 
 gulp.task('watch-optimize-images', () => {


### PR DESCRIPTION
Tried to run a build after the gulp update and got an error. Apparently you now have to either call a done event or return a stream from a Gulp task. 

This gets the `npm run build` or `gulp build` completely functional again.