### PR TITLE
Lock sortable version to 1.7.0 to prevent bugs from recent updates.

### DIFF
--- a/dist/esri-global-nav.js
+++ b/dist/esri-global-nav.js
@@ -657,7 +657,7 @@ var $close = {
 };
 
 var $grid = {
-  md: ["M6 2v4H2V2zm16 0v4h-4V2zm-8 0v4h-4V2zM6 18v4H2v-4zm16 0v4h-4v-4zm-8 0v4h-4v-4zm-8-8v4H2v-4zm16 0v4h-4v-4zm-8 0v4h-4v-4z"]
+  md: ["M11.5 18.05a1.45 1.45 0 1 0 1.45 1.45 1.45 1.45 0 0 0-1.45-1.45zM12 20h-1v-1h1zM3.5 2.05A1.45 1.45 0 1 0 4.95 3.5 1.45 1.45 0 0 0 3.5 2.05zM4 4H3V3h1zm7.5 6.05a1.45 1.45 0 1 0 1.45 1.45 1.45 1.45 0 0 0-1.45-1.45zM12 12h-1v-1h1zm-8.5-1.95a1.45 1.45 0 1 0 1.45 1.45 1.45 1.45 0 0 0-1.45-1.45zM4 12H3v-1h1zm-.5 6.05a1.45 1.45 0 1 0 1.45 1.45 1.45 1.45 0 0 0-1.45-1.45zM4 20H3v-1h1zM19.5 4.95a1.45 1.45 0 1 0-1.45-1.45 1.45 1.45 0 0 0 1.45 1.45zM19 3h1v1h-1zm.5 7.05a1.45 1.45 0 1 0 1.45 1.45 1.45 1.45 0 0 0-1.45-1.45zM20 12h-1v-1h1zm-8.5-9.95a1.45 1.45 0 1 0 1.45 1.45 1.45 1.45 0 0 0-1.45-1.45zM12 4h-1V3h1zm7.5 14.05a1.45 1.45 0 1 0 1.45 1.45 1.45 1.45 0 0 0-1.45-1.45zM20 20h-1v-1h1z"]
 };
 
 var $hamburger = {
@@ -1344,7 +1344,6 @@ var Sortable = createCommonjsModule(function (module) {
 	/**!
   * Sortable
   * @author	RubaXa   <trash@rubaxa.org>
-  * @author	owenm    <owen23355@gmail.com>
   * @license MIT
   */
 
@@ -1375,35 +1374,22 @@ var Sortable = createCommonjsModule(function (module) {
 		    scrollEl,
 		    scrollParentEl,
 		    scrollCustomFn,
+		    lastEl,
+		    lastCSS,
+		    lastParentCSS,
 		    oldIndex,
 		    newIndex,
 		    activeGroup,
 		    putSortable,
-		    autoScrolls = [],
-		    scrolling = false,
-		    awaitingDragStarted = false,
-		    ignoreNextClick = false,
-		    sortables = [],
-		    pointerElemChangedInterval,
-		    lastPointerElemX,
-		    lastPointerElemY,
+		    autoScroll = {},
 		    tapEvt,
 		    touchEvt,
 		    moved,
-		    lastTarget,
-		    lastDirection,
-		    pastFirstInvertThresh = false,
-		    isCircumstantialInvert = false,
-		    lastMode,
-		    // 'swap' or 'insert'
 
-		targetMoveDistance,
-		    forRepaintDummy,
-		    realDragElRect,
-		    // dragEl rect after current animation
 
 		/** @const */
 		R_SPACE = /\s+/g,
+		    R_FLOAT = /left|right|inline/,
 		    expando = 'Sortable' + new Date().getTime(),
 		    win = window,
 		    document = win.document,
@@ -1411,258 +1397,115 @@ var Sortable = createCommonjsModule(function (module) {
 		    setTimeout = win.setTimeout,
 		    $ = win.jQuery || win.Zepto,
 		    Polymer = win.Polymer,
-		    captureMode = {
-			capture: false,
-			passive: false
-		},
-		    IE11OrLess = !!navigator.userAgent.match(/(?:Trident.*rv[ :]?11\.|msie|iemobile)/i),
-		    Edge = !!navigator.userAgent.match(/Edge/i),
-
-		// FireFox = !!navigator.userAgent.match(/firefox/i),
-
-		CSSFloatProperty = Edge || IE11OrLess ? 'cssFloat' : 'float',
-
-
-		// This will not pass for IE9, because IE9 DnD only works on anchors
-		supportDraggable = 'draggable' in document.createElement('div'),
-		    supportCssPointerEvents = function () {
-			// false when <= IE11
-			if (IE11OrLess) {
+		    captureMode = false,
+		    passiveMode = false,
+		    supportDraggable = 'draggable' in document.createElement('div'),
+		    supportCssPointerEvents = function (el) {
+			// false when IE11
+			if (!!navigator.userAgent.match(/(?:Trident.*rv[ :]?11\.|msie)/i)) {
 				return false;
 			}
-			var el = document.createElement('x');
+			el = document.createElement('x');
 			el.style.cssText = 'pointer-events:auto';
 			return el.style.pointerEvents === 'auto';
 		}(),
 		    _silent = false,
-		    _alignedSilent = false,
 		    abs = Math.abs,
 		    min = Math.min,
 		    savedInputChecked = [],
-		    _detectDirection = function _detectDirection(el, options) {
-			var elCSS = _css(el),
-			    elWidth = parseInt(elCSS.width),
-			    child1 = _getChild(el, 0, options),
-			    child2 = _getChild(el, 1, options),
-			    firstChildCSS = child1 && _css(child1),
-			    secondChildCSS = child2 && _css(child2),
-			    firstChildWidth = firstChildCSS && parseInt(firstChildCSS.marginLeft) + parseInt(firstChildCSS.marginRight) + _getRect(child1).width,
-			    secondChildWidth = secondChildCSS && parseInt(secondChildCSS.marginLeft) + parseInt(secondChildCSS.marginRight) + _getRect(child2).width;
-			if (elCSS.display === 'flex') {
-				return elCSS.flexDirection === 'column' || elCSS.flexDirection === 'column-reverse' ? 'vertical' : 'horizontal';
-			}
-			return child1 && (firstChildCSS.display === 'block' || firstChildCSS.display === 'flex' || firstChildCSS.display === 'table' || firstChildCSS.display === 'grid' || firstChildWidth >= elWidth && elCSS[CSSFloatProperty] === 'none' || child2 && elCSS[CSSFloatProperty] === 'none' && firstChildWidth + secondChildWidth > elWidth) ? 'vertical' : 'horizontal';
-		},
-
-
-		/**
-   * Detects first nearest empty sortable to X and Y position using emptyInsertThreshold.
-   * @param  {Number} x      X position
-   * @param  {Number} y      Y position
-   * @return {HTMLElement}   Element of the first found nearest Sortable
-   */
-		_detectNearestEmptySortable = function _detectNearestEmptySortable(x, y) {
-			for (var i = 0; i < sortables.length; i++) {
-				if (sortables[i].children.length) continue;
-
-				var rect = _getRect(sortables[i]),
-				    threshold = sortables[i][expando].options.emptyInsertThreshold,
-				    insideHorizontally = x >= rect.left - threshold && x <= rect.right + threshold,
-				    insideVertically = y >= rect.top - threshold && y <= rect.bottom + threshold;
-
-				if (insideHorizontally && insideVertically) {
-					return sortables[i];
-				}
-			}
-		},
-		    _isClientInRowColumn = function _isClientInRowColumn(x, y, el, axis, options) {
-			var targetRect = _getRect(el),
-			    targetS1Opp = axis === 'vertical' ? targetRect.left : targetRect.top,
-			    targetS2Opp = axis === 'vertical' ? targetRect.right : targetRect.bottom,
-			    mouseOnOppAxis = axis === 'vertical' ? x : y;
-
-			return targetS1Opp < mouseOnOppAxis && mouseOnOppAxis < targetS2Opp;
-		},
-		    _isElInRowColumn = function _isElInRowColumn(el1, el2, axis) {
-			var el1Rect = el1 === dragEl && realDragElRect || _getRect(el1),
-			    el2Rect = el2 === dragEl && realDragElRect || _getRect(el2),
-			    el1S1Opp = axis === 'vertical' ? el1Rect.left : el1Rect.top,
-			    el1S2Opp = axis === 'vertical' ? el1Rect.right : el1Rect.bottom,
-			    el1OppLength = axis === 'vertical' ? el1Rect.width : el1Rect.height,
-			    el2S1Opp = axis === 'vertical' ? el2Rect.left : el2Rect.top,
-			    el2S2Opp = axis === 'vertical' ? el2Rect.right : el2Rect.bottom,
-			    el2OppLength = axis === 'vertical' ? el2Rect.width : el2Rect.height;
-
-			return el1S1Opp === el2S1Opp || el1S2Opp === el2S2Opp || el1S1Opp + el1OppLength / 2 === el2S1Opp + el2OppLength / 2;
-		},
-		    _getParentAutoScrollElement = function _getParentAutoScrollElement(el, includeSelf) {
-			// skip to window
-			if (!el || !el.getBoundingClientRect) return win;
-
-			var elem = el;
-			var gotSelf = false;
-			do {
-				// we don't need to get elem css if it isn't even overflowing in the first place (performance)
-				if (elem.clientWidth < elem.scrollWidth || elem.clientHeight < elem.scrollHeight) {
-					var elemCSS = _css(elem);
-					if (elem.clientWidth < elem.scrollWidth && (elemCSS.overflowX == 'auto' || elemCSS.overflowX == 'scroll') || elem.clientHeight < elem.scrollHeight && (elemCSS.overflowY == 'auto' || elemCSS.overflowY == 'scroll')) {
-						if (!elem || !elem.getBoundingClientRect || elem === document.body) return win;
-
-						if (gotSelf || includeSelf) return elem;
-						gotSelf = true;
-					}
-				}
-				/* jshint boss:true */
-			} while (elem = elem.parentNode);
-
-			return win;
-		},
-		    _autoScroll = _throttle(function ( /**Event*/evt, /**Object*/options, /**HTMLElement*/rootEl, /**Boolean*/isFallback) {
+		    touchDragOverListeners = [],
+		    _autoScroll = _throttle(function ( /**Event*/evt, /**Object*/options, /**HTMLElement*/rootEl) {
 			// Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=505521
-			if (options.scroll) {
-				var _this = rootEl ? rootEl[expando] : window,
+			if (rootEl && options.scroll) {
+				var _this = rootEl[expando],
+				    el,
+				    rect,
 				    sens = options.scrollSensitivity,
 				    speed = options.scrollSpeed,
 				    x = evt.clientX,
 				    y = evt.clientY,
 				    winWidth = window.innerWidth,
 				    winHeight = window.innerHeight,
-				    scrollThisInstance = false;
+				    vx,
+				    vy,
+				    scrollOffsetX,
+				    scrollOffsetY;
 
-				// Detect scrollEl
+				// Delect scrollEl
 				if (scrollParentEl !== rootEl) {
-					_clearAutoScrolls();
-
 					scrollEl = options.scroll;
+					scrollParentEl = rootEl;
 					scrollCustomFn = options.scrollFn;
 
 					if (scrollEl === true) {
-						scrollEl = _getParentAutoScrollElement(rootEl, true);
-						scrollParentEl = scrollEl;
+						scrollEl = rootEl;
+
+						do {
+							if (scrollEl.offsetWidth < scrollEl.scrollWidth || scrollEl.offsetHeight < scrollEl.scrollHeight) {
+								break;
+							}
+							/* jshint boss:true */
+						} while (scrollEl = scrollEl.parentNode);
 					}
 				}
 
-				var layersOut = 0;
-				var currentParent = scrollEl;
-				do {
-					var el = currentParent,
-					    rect = _getRect(el),
-					    top = rect.top,
-					    bottom = rect.bottom,
-					    left = rect.left,
-					    right = rect.right,
-					    width = rect.width,
-					    height = rect.height,
-					    scrollWidth,
-					    scrollHeight,
-					    css,
-					    vx,
-					    vy,
-					    canScrollX,
-					    canScrollY,
-					    scrollPosX,
-					    scrollPosY;
+				if (scrollEl) {
+					el = scrollEl;
+					rect = scrollEl.getBoundingClientRect();
+					vx = (abs(rect.right - x) <= sens) - (abs(rect.left - x) <= sens);
+					vy = (abs(rect.bottom - y) <= sens) - (abs(rect.top - y) <= sens);
+				}
 
-					if (el !== win) {
-						scrollWidth = el.scrollWidth;
-						scrollHeight = el.scrollHeight;
+				if (!(vx || vy)) {
+					vx = (winWidth - x <= sens) - (x <= sens);
+					vy = (winHeight - y <= sens) - (y <= sens);
 
-						css = _css(el);
+					/* jshint expr:true */
+					(vx || vy) && (el = win);
+				}
 
-						canScrollX = width < scrollWidth && (css.overflowX === 'auto' || css.overflowX === 'scroll');
-						canScrollY = height < scrollHeight && (css.overflowY === 'auto' || css.overflowY === 'scroll');
+				if (autoScroll.vx !== vx || autoScroll.vy !== vy || autoScroll.el !== el) {
+					autoScroll.el = el;
+					autoScroll.vx = vx;
+					autoScroll.vy = vy;
 
-						scrollPosX = el.scrollLeft;
-						scrollPosY = el.scrollTop;
-					} else {
-						scrollWidth = document.documentElement.scrollWidth;
-						scrollHeight = document.documentElement.scrollHeight;
+					clearInterval(autoScroll.pid);
 
-						css = _css(document.documentElement);
+					if (el) {
+						autoScroll.pid = setInterval(function () {
+							scrollOffsetY = vy ? vy * speed : 0;
+							scrollOffsetX = vx ? vx * speed : 0;
 
-						canScrollX = width < scrollWidth && (css.overflowX === 'auto' || css.overflowX === 'scroll' || css.overflowX === 'visible');
-						canScrollY = height < scrollHeight && (css.overflowY === 'auto' || css.overflowY === 'scroll' || css.overflowY === 'visible');
-
-						scrollPosX = document.documentElement.scrollLeft;
-						scrollPosY = document.documentElement.scrollTop;
-					}
-
-					vx = canScrollX && (abs(right - x) <= sens && scrollPosX + width < scrollWidth) - (abs(left - x) <= sens && !!scrollPosX);
-
-					vy = canScrollY && (abs(bottom - y) <= sens && scrollPosY + height < scrollHeight) - (abs(top - y) <= sens && !!scrollPosY);
-
-					if (!autoScrolls[layersOut]) {
-						for (var i = 0; i <= layersOut; i++) {
-							if (!autoScrolls[i]) {
-								autoScrolls[i] = {};
+							if ('function' === typeof scrollCustomFn) {
+								return scrollCustomFn.call(_this, scrollOffsetX, scrollOffsetY, evt);
 							}
-						}
+
+							if (el === win) {
+								win.scrollTo(win.pageXOffset + scrollOffsetX, win.pageYOffset + scrollOffsetY);
+							} else {
+								el.scrollTop += scrollOffsetY;
+								el.scrollLeft += scrollOffsetX;
+							}
+						}, 24);
 					}
-
-					if (autoScrolls[layersOut].vx != vx || autoScrolls[layersOut].vy != vy || autoScrolls[layersOut].el !== el) {
-						autoScrolls[layersOut].el = el;
-						autoScrolls[layersOut].vx = vx;
-						autoScrolls[layersOut].vy = vy;
-
-						clearInterval(autoScrolls[layersOut].pid);
-
-						if (el && (vx != 0 || vy != 0)) {
-							scrollThisInstance = true;
-							/* jshint loopfunc:true */
-							autoScrolls[layersOut].pid = setInterval(function () {
-								// emulate drag over during autoscroll (fallback), emulating native DnD behaviour
-								if (isFallback && this.layer === 0) {
-									Sortable.active._emulateDragOver(true);
-								}
-								var scrollOffsetY = autoScrolls[this.layer].vy ? autoScrolls[this.layer].vy * speed : 0;
-								var scrollOffsetX = autoScrolls[this.layer].vx ? autoScrolls[this.layer].vx * speed : 0;
-
-								if ('function' === typeof scrollCustomFn) {
-									if (scrollCustomFn.call(_this, scrollOffsetX, scrollOffsetY, evt, touchEvt, autoScrolls[this.layer].el) !== 'continue') {
-										return;
-									}
-								}
-								if (autoScrolls[this.layer].el === win) {
-									win.scrollTo(win.pageXOffset + scrollOffsetX, win.pageYOffset + scrollOffsetY);
-								} else {
-									autoScrolls[this.layer].el.scrollTop += scrollOffsetY;
-									autoScrolls[this.layer].el.scrollLeft += scrollOffsetX;
-								}
-							}.bind({ layer: layersOut }), 24);
-						}
-					}
-					layersOut++;
-				} while (options.bubbleScroll && currentParent !== win && (currentParent = _getParentAutoScrollElement(currentParent, false)));
-				scrolling = scrollThisInstance; // in case another function catches scrolling as false in between when it is not
+				}
 			}
 		}, 30),
-		    _clearAutoScrolls = function _clearAutoScrolls() {
-			autoScrolls.forEach(function (autoScroll) {
-				clearInterval(autoScroll.pid);
-			});
-			autoScrolls = [];
-		},
 		    _prepareGroup = function _prepareGroup(options) {
 			function toFn(value, pull) {
-				return function (to, from, dragEl, evt) {
-					var sameGroup = to.options.group.name && from.options.group.name && to.options.group.name === from.options.group.name;
+				if (value === void 0 || value === true) {
+					value = group.name;
+				}
 
-					if (value == null && (pull || sameGroup)) {
-						// Default pull value
-						// Default pull and put value if same group
-						return true;
-					} else if (value == null || value === false) {
-						return false;
-					} else if (pull && value === 'clone') {
-						return value;
-					} else if (typeof value === 'function') {
-						return toFn(value(to, from, dragEl, evt), pull)(to, from, dragEl, evt);
-					} else {
-						var otherGroup = (pull ? to : from).options.group.name;
+				if (typeof value === 'function') {
+					return value;
+				} else {
+					return function (to, from) {
+						var fromGroup = from.options.group.name;
 
-						return value === true || typeof value === 'string' && value === otherGroup || value.join && value.indexOf(otherGroup) > -1;
-					}
-				};
+						return pull ? value : value && (value.join ? value.indexOf(fromGroup) > -1 : fromGroup == value);
+					};
+				}
 			}
 
 			var group = {};
@@ -1678,71 +1521,22 @@ var Sortable = createCommonjsModule(function (module) {
 			group.revertClone = originalGroup.revertClone;
 
 			options.group = group;
-		},
-		    _checkAlignment = function _checkAlignment(evt) {
-			if (!dragEl || !dragEl.parentNode) return;
-			dragEl.parentNode[expando] && dragEl.parentNode[expando]._computeIsAligned(evt);
-		},
-		    _isTrueParentSortable = function _isTrueParentSortable(el, target) {
-			var trueParent = target;
-			while (!trueParent[expando]) {
-				trueParent = trueParent.parentNode;
-			}
-
-			return el === trueParent;
-		},
-		    _artificalBubble = function _artificalBubble(sortable, originalEvt, method) {
-			// Artificial IE bubbling
-			var nextParent = sortable.parentNode;
-			while (nextParent && !nextParent[expando]) {
-				nextParent = nextParent.parentNode;
-			}
-
-			if (nextParent) {
-				nextParent[expando][method](_extend(originalEvt, {
-					artificialBubble: true
-				}));
-			}
-		},
-		    _hideGhostForTarget = function _hideGhostForTarget() {
-			if (!supportCssPointerEvents && ghostEl) {
-				_css(ghostEl, 'display', 'none');
-			}
-		},
-		    _unhideGhostForTarget = function _unhideGhostForTarget() {
-			if (!supportCssPointerEvents && ghostEl) {
-				_css(ghostEl, 'display', '');
-			}
 		};
 
-		// #1184 fix - Prevent click event on fallback if dragged but item not changed position
-		document.addEventListener('click', function (evt) {
-			if (ignoreNextClick) {
-				evt.preventDefault();
-				evt.stopPropagation && evt.stopPropagation();
-				evt.stopImmediatePropagation && evt.stopImmediatePropagation();
-				ignoreNextClick = false;
-				return false;
-			}
-		}, true);
-
-		var nearestEmptyInsertDetectEvent = function nearestEmptyInsertDetectEvent(evt) {
-			if (dragEl) {
-				var nearest = _detectNearestEmptySortable(evt.clientX, evt.clientY);
-
-				if (nearest) {
-					nearest[expando]._onDragOver({
-						clientX: evt.clientX,
-						clientY: evt.clientY,
-						target: nearest,
-						rootEl: nearest
-					});
+		// Detect support a passive mode
+		try {
+			window.addEventListener('test', null, Object.defineProperty({}, 'passive', {
+				get: function get$$1() {
+					// `false`, because everything starts to work incorrectly and instead of d'n'd,
+					// begins the page has scrolled.
+					passiveMode = false;
+					captureMode = {
+						capture: false,
+						passive: passiveMode
+					};
 				}
-			}
-		};
-		// We do not want this to be triggered if completed (bubbling canceled), so only define it here
-		document.addEventListener('dragover', nearestEmptyInsertDetectEvent);
-		document.addEventListener('mousemove', nearestEmptyInsertDetectEvent);
+			}));
+		} catch (err) {}
 
 		/**
    * @class  Sortable
@@ -1751,7 +1545,7 @@ var Sortable = createCommonjsModule(function (module) {
    */
 		function Sortable(el, options) {
 			if (!(el && el.nodeType && el.nodeType === 1)) {
-				throw 'Sortable: `el` must be HTMLElement, not ' + {}.toString.call(el);
+				throw 'Sortable: `el` must be HTMLElement, and not ' + {}.toString.call(el);
 			}
 
 			this.el = el; // root element
@@ -1762,7 +1556,7 @@ var Sortable = createCommonjsModule(function (module) {
 
 			// Default options
 			var defaults$$1 = {
-				group: null,
+				group: Math.random(),
 				sort: true,
 				disabled: false,
 				store: null,
@@ -1770,15 +1564,7 @@ var Sortable = createCommonjsModule(function (module) {
 				scroll: true,
 				scrollSensitivity: 30,
 				scrollSpeed: 10,
-				bubbleScroll: true,
 				draggable: /[uo]l/i.test(el.nodeName) ? 'li' : '>*',
-				swapThreshold: 1, // percentage; 0 <= x <= 1
-				invertSwap: false, // invert always
-				invertedSwapThreshold: null, // will be set to same as swapThreshold if default
-				removeCloneOnHide: true,
-				direction: function direction() {
-					return _detectDirection(el, this.options);
-				},
 				ghostClass: 'sortable-ghost',
 				chosenClass: 'sortable-chosen',
 				dragClass: 'sortable-drag',
@@ -1786,7 +1572,6 @@ var Sortable = createCommonjsModule(function (module) {
 				filter: null,
 				preventOnFilter: true,
 				animation: 0,
-				easing: null,
 				setData: function setData(dataTransfer, dragEl) {
 					dataTransfer.setData('Text', dragEl.textContent);
 				},
@@ -1794,15 +1579,12 @@ var Sortable = createCommonjsModule(function (module) {
 				dragoverBubble: false,
 				dataIdAttr: 'data-id',
 				delay: 0,
-				touchStartThreshold: parseInt(window.devicePixelRatio, 10) || 1,
 				forceFallback: false,
 				fallbackClass: 'sortable-fallback',
 				fallbackOnBody: false,
 				fallbackTolerance: 0,
 				fallbackOffset: { x: 0, y: 0 },
-				supportPointer: Sortable.supportPointer !== false && ('PointerEvent' in window || window.navigator && 'msPointerEnabled' in window.navigator // microsoft
-				),
-				emptyInsertThreshold: 5
+				supportPointer: Sortable.supportPointer !== false
 			};
 
 			// Set default options
@@ -1823,67 +1605,25 @@ var Sortable = createCommonjsModule(function (module) {
 			this.nativeDraggable = options.forceFallback ? false : supportDraggable;
 
 			// Bind events
-			if (options.supportPointer) {
-				_on(el, 'pointerdown', this._onTapStart);
-			} else {
-				_on(el, 'mousedown', this._onTapStart);
-				_on(el, 'touchstart', this._onTapStart);
-			}
+			_on(el, 'mousedown', this._onTapStart);
+			_on(el, 'touchstart', this._onTapStart);
+			options.supportPointer && _on(el, 'pointerdown', this._onTapStart);
 
 			if (this.nativeDraggable) {
 				_on(el, 'dragover', this);
 				_on(el, 'dragenter', this);
 			}
 
-			sortables.push(this.el);
+			touchDragOverListeners.push(this._onDragOver);
 
 			// Restore sorting
-			options.store && options.store.get && this.sort(options.store.get(this) || []);
+			options.store && this.sort(options.store.get(this));
 		}
 
 		Sortable.prototype = /** @lends Sortable.prototype */{
 			constructor: Sortable,
 
-			_computeIsAligned: function _computeIsAligned(evt) {
-				var target;
-
-				if (ghostEl && !supportCssPointerEvents) {
-					_hideGhostForTarget();
-					target = document.elementFromPoint(evt.clientX, evt.clientY);
-					_unhideGhostForTarget();
-				} else {
-					target = evt.target;
-				}
-
-				target = _closest(target, this.options.draggable, this.el, false);
-				if (_alignedSilent) return;
-				if (!dragEl || dragEl.parentNode !== this.el) return;
-
-				var children = this.el.children;
-				for (var i = 0; i < children.length; i++) {
-					// Don't change for target in case it is changed to aligned before onDragOver is fired
-					if (_closest(children[i], this.options.draggable, this.el, false) && children[i] !== target) {
-						children[i].sortableMouseAligned = _isClientInRowColumn(evt.clientX, evt.clientY, children[i], this._getDirection(evt, null), this.options);
-					}
-				}
-				// Used for nulling last target when not in element, nothing to do with checking if aligned
-				if (!_closest(target, this.options.draggable, this.el, true)) {
-					lastTarget = null;
-				}
-
-				_alignedSilent = true;
-				setTimeout(function () {
-					_alignedSilent = false;
-				}, 30);
-			},
-
-			_getDirection: function _getDirection(evt, target) {
-				return typeof this.options.direction === 'function' ? this.options.direction.call(this, evt, target, dragEl) : this.options.direction;
-			},
-
 			_onTapStart: function _onTapStart( /** Event|TouchEvent */evt) {
-				if (!evt.cancelable) return;
-
 				var _this = this,
 				    el = this.el,
 				    options = this.options,
@@ -1891,17 +1631,11 @@ var Sortable = createCommonjsModule(function (module) {
 				    type = evt.type,
 				    touch = evt.touches && evt.touches[0],
 				    target = (touch || evt).target,
-				    originalTarget = evt.target.shadowRoot && (evt.path && evt.path[0] || evt.composedPath && evt.composedPath()[0]) || target,
+				    originalTarget = evt.target.shadowRoot && evt.path && evt.path[0] || target,
 				    filter = options.filter,
 				    startIndex;
 
 				_saveInputCheckedState(el);
-
-				// IE: Calls events in capture mode if event element is nested. This ensures only correct element's _onTapStart goes through.
-				// This process is also done in _onDragOver
-				if (IE11OrLess && !evt.artificialBubble && !_isTrueParentSortable(el, target)) {
-					return;
-				}
 
 				// Don't trigger start event when an element is been dragged, otherwise the evt.oldindex always wrong when set option.group.
 				if (dragEl) {
@@ -1909,7 +1643,7 @@ var Sortable = createCommonjsModule(function (module) {
 				}
 
 				if (/mousedown|pointerdown/.test(type) && evt.button !== 0 || options.disabled) {
-					return; // only left button and enabled
+					return; // only left button or enabled
 				}
 
 				// cancel dnd if original target is content editable
@@ -1917,12 +1651,9 @@ var Sortable = createCommonjsModule(function (module) {
 					return;
 				}
 
-				target = _closest(target, options.draggable, el, false);
+				target = _closest(target, options.draggable, el);
 
 				if (!target) {
-					if (IE11OrLess) {
-						_artificalBubble(el, evt, '_onTapStart');
-					}
 					return;
 				}
 
@@ -1938,12 +1669,12 @@ var Sortable = createCommonjsModule(function (module) {
 				if (typeof filter === 'function') {
 					if (filter.call(this, evt, target, this)) {
 						_dispatchEvent(_this, originalTarget, 'filter', target, el, el, startIndex);
-						preventOnFilter && evt.cancelable && evt.preventDefault();
+						preventOnFilter && evt.preventDefault();
 						return; // cancel dnd
 					}
 				} else if (filter) {
 					filter = filter.split(',').some(function (criteria) {
-						criteria = _closest(originalTarget, criteria.trim(), el, false);
+						criteria = _closest(originalTarget, criteria.trim(), el);
 
 						if (criteria) {
 							_dispatchEvent(_this, criteria, 'filter', target, el, el, startIndex);
@@ -1952,59 +1683,17 @@ var Sortable = createCommonjsModule(function (module) {
 					});
 
 					if (filter) {
-						preventOnFilter && evt.cancelable && evt.preventDefault();
+						preventOnFilter && evt.preventDefault();
 						return; // cancel dnd
 					}
 				}
 
-				if (options.handle && !_closest(originalTarget, options.handle, el, false)) {
+				if (options.handle && !_closest(originalTarget, options.handle, el)) {
 					return;
 				}
 
 				// Prepare `dragstart`
 				this._prepareDragStart(evt, touch, target, startIndex);
-			},
-
-			_handleAutoScroll: function _handleAutoScroll(evt, fallback) {
-				if (!dragEl || !this.options.scroll) return;
-				var x = evt.clientX,
-				    y = evt.clientY,
-				    elem = document.elementFromPoint(x, y),
-				    _this = this;
-
-				// IE does not seem to have native autoscroll,
-				// Edge's autoscroll seems too conditional,
-				// Firefox and Chrome are good
-				if (fallback || Edge || IE11OrLess) {
-					_autoScroll(evt, _this.options, elem, fallback);
-
-					// Listener for pointer element change
-					var ogElemScroller = _getParentAutoScrollElement(elem, true);
-					if (scrolling && (!pointerElemChangedInterval || x !== lastPointerElemX || y !== lastPointerElemY)) {
-
-						pointerElemChangedInterval && clearInterval(pointerElemChangedInterval);
-						// Detect for pointer elem change, emulating native DnD behaviour
-						pointerElemChangedInterval = setInterval(function () {
-							if (!dragEl) return;
-							// could also check if scroll direction on newElem changes due to parent autoscrolling
-							var newElem = _getParentAutoScrollElement(document.elementFromPoint(x, y), true);
-							if (newElem !== ogElemScroller) {
-								ogElemScroller = newElem;
-								_clearAutoScrolls();
-								_autoScroll(evt, _this.options, ogElemScroller, fallback);
-							}
-						}, 10);
-						lastPointerElemX = x;
-						lastPointerElemY = y;
-					}
-				} else {
-					// if DnD is enabled (and browser has good autoscrolling), first autoscroll will already scroll, so get parent autoscroll of first autoscroll
-					if (!_this.options.bubbleScroll || _getParentAutoScrollElement(elem, true) === window) {
-						_clearAutoScrolls();
-						return;
-					}
-					_autoScroll(evt, _this.options, _getParentAutoScrollElement(elem, false), false);
-				}
 			},
 
 			_prepareDragStart: function _prepareDragStart( /** Event */evt, /** Touch */touch, /** HTMLElement */target, /** Number */startIndex) {
@@ -2015,6 +1704,8 @@ var Sortable = createCommonjsModule(function (module) {
 				    dragStartFn;
 
 				if (target && !dragEl && target.parentNode === el) {
+					tapEvt = evt;
+
 					rootEl = el;
 					dragEl = target;
 					parentEl = dragEl.parentNode;
@@ -2023,19 +1714,10 @@ var Sortable = createCommonjsModule(function (module) {
 					activeGroup = options.group;
 					oldIndex = startIndex;
 
-					tapEvt = {
-						target: dragEl,
-						clientX: (touch || evt).clientX,
-						clientY: (touch || evt).clientY
-					};
-
 					this._lastX = (touch || evt).clientX;
 					this._lastY = (touch || evt).clientY;
 
 					dragEl.style['will-change'] = 'all';
-					// undo animation if needed
-					dragEl.style.transition = '';
-					dragEl.style.transform = '';
 
 					dragStartFn = function dragStartFn() {
 						// Delayed drag has been triggered
@@ -2045,14 +1727,14 @@ var Sortable = createCommonjsModule(function (module) {
 						// Make the element draggable
 						dragEl.draggable = _this.nativeDraggable;
 
+						// Chosen item
+						_toggleClass(dragEl, options.chosenClass, true);
+
 						// Bind the events: dragstart/dragend
 						_this._triggerDragStart(evt, touch);
 
 						// Drag start event
 						_dispatchEvent(_this, rootEl, 'choose', dragEl, rootEl, rootEl, oldIndex);
-
-						// Chosen item
-						_toggleClass(dragEl, options.chosenClass, true);
 					};
 
 					// Disable "draggable"
@@ -2060,14 +1742,11 @@ var Sortable = createCommonjsModule(function (module) {
 						_find(dragEl, criteria.trim(), _disableDraggable);
 					});
 
-					if (options.supportPointer) {
-						_on(ownerDocument, 'pointerup', _this._onDrop);
-						_on(ownerDocument, 'pointercancel', _this._onDrop);
-					} else {
-						_on(ownerDocument, 'mouseup', _this._onDrop);
-						_on(ownerDocument, 'touchend', _this._onDrop);
-						_on(ownerDocument, 'touchcancel', _this._onDrop);
-					}
+					_on(ownerDocument, 'mouseup', _this._onDrop);
+					_on(ownerDocument, 'touchend', _this._onDrop);
+					_on(ownerDocument, 'touchcancel', _this._onDrop);
+					_on(ownerDocument, 'selectstart', _this);
+					options.supportPointer && _on(ownerDocument, 'pointercancel', _this._onDrop);
 
 					if (options.delay) {
 						// If the user moves the pointer or let go the click or touch
@@ -2076,21 +1755,14 @@ var Sortable = createCommonjsModule(function (module) {
 						_on(ownerDocument, 'mouseup', _this._disableDelayedDrag);
 						_on(ownerDocument, 'touchend', _this._disableDelayedDrag);
 						_on(ownerDocument, 'touchcancel', _this._disableDelayedDrag);
-						_on(ownerDocument, 'mousemove', _this._delayedDragTouchMoveHandler);
-						_on(ownerDocument, 'touchmove', _this._delayedDragTouchMoveHandler);
-						options.supportPointer && _on(ownerDocument, 'pointermove', _this._delayedDragTouchMoveHandler);
+						_on(ownerDocument, 'mousemove', _this._disableDelayedDrag);
+						_on(ownerDocument, 'touchmove', _this._disableDelayedDrag);
+						options.supportPointer && _on(ownerDocument, 'pointermove', _this._disableDelayedDrag);
 
 						_this._dragStartTimer = setTimeout(dragStartFn, options.delay);
 					} else {
 						dragStartFn();
 					}
-				}
-			},
-
-			_delayedDragTouchMoveHandler: function _delayedDragTouchMoveHandler( /** TouchEvent|PointerEvent **/e) {
-				var touch = e.touches ? e.touches[0] : e;
-				if (min(abs(touch.clientX - this._lastX), abs(touch.clientY - this._lastY)) >= this.options.touchStartThreshold) {
-					this._disableDelayedDrag();
 				}
 			},
 
@@ -2101,22 +1773,25 @@ var Sortable = createCommonjsModule(function (module) {
 				_off(ownerDocument, 'mouseup', this._disableDelayedDrag);
 				_off(ownerDocument, 'touchend', this._disableDelayedDrag);
 				_off(ownerDocument, 'touchcancel', this._disableDelayedDrag);
-				_off(ownerDocument, 'mousemove', this._delayedDragTouchMoveHandler);
-				_off(ownerDocument, 'touchmove', this._delayedDragTouchMoveHandler);
-				_off(ownerDocument, 'pointermove', this._delayedDragTouchMoveHandler);
+				_off(ownerDocument, 'mousemove', this._disableDelayedDrag);
+				_off(ownerDocument, 'touchmove', this._disableDelayedDrag);
+				_off(ownerDocument, 'pointermove', this._disableDelayedDrag);
 			},
 
 			_triggerDragStart: function _triggerDragStart( /** Event */evt, /** Touch */touch) {
 				touch = touch || (evt.pointerType == 'touch' ? evt : null);
 
-				if (!this.nativeDraggable || touch) {
-					if (this.options.supportPointer) {
-						_on(document, 'pointermove', this._onTouchMove);
-					} else if (touch) {
-						_on(document, 'touchmove', this._onTouchMove);
-					} else {
-						_on(document, 'mousemove', this._onTouchMove);
-					}
+				if (touch) {
+					// Touch device support
+					tapEvt = {
+						target: dragEl,
+						clientX: touch.clientX,
+						clientY: touch.clientY
+					};
+
+					this._onDragStart(tapEvt, 'touch');
+				} else if (!this.nativeDraggable) {
+					this._onDragStart(tapEvt, true);
 				} else {
 					_on(dragEl, 'dragend', this);
 					_on(rootEl, 'dragstart', this._onDragStart);
@@ -2134,25 +1809,15 @@ var Sortable = createCommonjsModule(function (module) {
 				} catch (err) {}
 			},
 
-			_dragStarted: function _dragStarted(fallback) {
-				awaitingDragStarted = false;
+			_dragStarted: function _dragStarted() {
 				if (rootEl && dragEl) {
-					if (this.nativeDraggable) {
-						_on(document, 'dragover', this._handleAutoScroll);
-						_on(document, 'dragover', _checkAlignment);
-					}
 					var options = this.options;
 
 					// Apply effect
-					!fallback && _toggleClass(dragEl, options.dragClass, false);
 					_toggleClass(dragEl, options.ghostClass, true);
-
-					// In case dragging an animated element
-					_css(dragEl, 'transform', '');
+					_toggleClass(dragEl, options.dragClass, false);
 
 					Sortable.active = this;
-
-					fallback && this._appendGhost();
 
 					// Drag start event
 					_dispatchEvent(this, rootEl, 'start', dragEl, rootEl, rootEl, oldIndex);
@@ -2161,20 +1826,24 @@ var Sortable = createCommonjsModule(function (module) {
 				}
 			},
 
-			_emulateDragOver: function _emulateDragOver(bypassLastTouchCheck) {
+			_emulateDragOver: function _emulateDragOver() {
 				if (touchEvt) {
-					if (this._lastX === touchEvt.clientX && this._lastY === touchEvt.clientY && !bypassLastTouchCheck) {
+					if (this._lastX === touchEvt.clientX && this._lastY === touchEvt.clientY) {
 						return;
 					}
+
 					this._lastX = touchEvt.clientX;
 					this._lastY = touchEvt.clientY;
 
-					_hideGhostForTarget();
+					if (!supportCssPointerEvents) {
+						_css(ghostEl, 'display', 'none');
+					}
 
 					var target = document.elementFromPoint(touchEvt.clientX, touchEvt.clientY);
 					var parent = target;
+					var i = touchDragOverListeners.length;
 
-					while (target && target.shadowRoot) {
+					if (target && target.shadowRoot) {
 						target = target.shadowRoot.elementFromPoint(touchEvt.clientX, touchEvt.clientY);
 						parent = target;
 					}
@@ -2182,18 +1851,16 @@ var Sortable = createCommonjsModule(function (module) {
 					if (parent) {
 						do {
 							if (parent[expando]) {
-								var inserted;
-
-								inserted = parent[expando]._onDragOver({
-									clientX: touchEvt.clientX,
-									clientY: touchEvt.clientY,
-									target: target,
-									rootEl: parent
-								});
-
-								if (inserted && !this.options.dragoverBubble) {
-									break;
+								while (i--) {
+									touchDragOverListeners[i]({
+										clientX: touchEvt.clientX,
+										clientY: touchEvt.clientY,
+										target: target,
+										rootEl: parent
+									});
 								}
+
+								break;
 							}
 
 							target = parent; // store last element
@@ -2201,35 +1868,34 @@ var Sortable = createCommonjsModule(function (module) {
 						/* jshint boss:true */
 						while (parent = parent.parentNode);
 					}
-					dragEl.parentNode[expando]._computeIsAligned(touchEvt);
 
-					_unhideGhostForTarget();
+					if (!supportCssPointerEvents) {
+						_css(ghostEl, 'display', '');
+					}
 				}
 			},
 
 			_onTouchMove: function _onTouchMove( /**TouchEvent*/evt) {
 				if (tapEvt) {
-					if (!evt.cancelable) return;
 					var options = this.options,
 					    fallbackTolerance = options.fallbackTolerance,
 					    fallbackOffset = options.fallbackOffset,
 					    touch = evt.touches ? evt.touches[0] : evt,
-					    matrix = ghostEl && _matrix(ghostEl),
-					    scaleX = ghostEl && matrix && matrix.a,
-					    scaleY = ghostEl && matrix && matrix.d,
-					    dx = (touch.clientX - tapEvt.clientX + fallbackOffset.x) / (scaleX ? scaleX : 1),
-					    dy = (touch.clientY - tapEvt.clientY + fallbackOffset.y) / (scaleY ? scaleY : 1),
+					    dx = touch.clientX - tapEvt.clientX + fallbackOffset.x,
+					    dy = touch.clientY - tapEvt.clientY + fallbackOffset.y,
 					    translate3d = evt.touches ? 'translate3d(' + dx + 'px,' + dy + 'px,0)' : 'translate(' + dx + 'px,' + dy + 'px)';
 
 					// only set the status to dragging, when we are actually dragging
-					if (!Sortable.active && !awaitingDragStarted) {
+					if (!Sortable.active) {
 						if (fallbackTolerance && min(abs(touch.clientX - this._lastX), abs(touch.clientY - this._lastY)) < fallbackTolerance) {
 							return;
 						}
-						this._onDragStart(evt, true);
+
+						this._dragStarted();
 					}
 
-					this._handleAutoScroll(touch, true);
+					// as well as creating the ghost element on the document body
+					this._appendGhost();
 
 					moved = true;
 					touchEvt = touch;
@@ -2239,15 +1905,16 @@ var Sortable = createCommonjsModule(function (module) {
 					_css(ghostEl, 'msTransform', translate3d);
 					_css(ghostEl, 'transform', translate3d);
 
-					evt.cancelable && evt.preventDefault();
+					evt.preventDefault();
 				}
 			},
 
 			_appendGhost: function _appendGhost() {
 				if (!ghostEl) {
-					var rect = _getRect(dragEl, this.options.fallbackOnBody ? document.body : rootEl, true),
+					var rect = dragEl.getBoundingClientRect(),
 					    css = _css(dragEl),
-					    options = this.options;
+					    options = this.options,
+					    ghostRect;
 
 					ghostEl = dragEl.cloneNode(true);
 
@@ -2255,10 +1922,8 @@ var Sortable = createCommonjsModule(function (module) {
 					_toggleClass(ghostEl, options.fallbackClass, true);
 					_toggleClass(ghostEl, options.dragClass, true);
 
-					_css(ghostEl, 'box-sizing', 'border-box');
-					_css(ghostEl, 'margin', 0);
-					_css(ghostEl, 'top', rect.top);
-					_css(ghostEl, 'left', rect.left);
+					_css(ghostEl, 'top', rect.top - parseInt(css.marginTop, 10));
+					_css(ghostEl, 'left', rect.left - parseInt(css.marginLeft, 10));
 					_css(ghostEl, 'width', rect.width);
 					_css(ghostEl, 'height', rect.height);
 					_css(ghostEl, 'opacity', '0.8');
@@ -2267,45 +1932,58 @@ var Sortable = createCommonjsModule(function (module) {
 					_css(ghostEl, 'pointerEvents', 'none');
 
 					options.fallbackOnBody && document.body.appendChild(ghostEl) || rootEl.appendChild(ghostEl);
+
+					// Fixing dimensions.
+					ghostRect = ghostEl.getBoundingClientRect();
+					_css(ghostEl, 'width', rect.width * 2 - ghostRect.width);
+					_css(ghostEl, 'height', rect.height * 2 - ghostRect.height);
 				}
 			},
 
-			_onDragStart: function _onDragStart( /**Event*/evt, /**boolean*/fallback) {
+			_onDragStart: function _onDragStart( /**Event*/evt, /**boolean*/useFallback) {
 				var _this = this;
 				var dataTransfer = evt.dataTransfer;
 				var options = _this.options;
 
-				// Setup clone
-				cloneEl = _clone(dragEl);
+				_this._offUpEvents();
 
-				cloneEl.draggable = false;
-				cloneEl.style['will-change'] = '';
+				if (activeGroup.checkPull(_this, _this, dragEl, evt)) {
+					cloneEl = _clone(dragEl);
 
-				this._hideClone();
+					cloneEl.draggable = false;
+					cloneEl.style['will-change'] = '';
 
-				_toggleClass(cloneEl, _this.options.chosenClass, false);
+					_css(cloneEl, 'display', 'none');
+					_toggleClass(cloneEl, _this.options.chosenClass, false);
 
-				// #1143: IFrame support workaround
-				_this._cloneId = _nextTick(function () {
-					if (!_this.options.removeCloneOnHide) {
+					// #1143: IFrame support workaround
+					_this._cloneId = _nextTick(function () {
 						rootEl.insertBefore(cloneEl, dragEl);
+						_dispatchEvent(_this, rootEl, 'clone', dragEl);
+					});
+				}
+
+				_toggleClass(dragEl, options.dragClass, true);
+
+				if (useFallback) {
+					if (useFallback === 'touch') {
+						// Bind touch events
+						_on(document, 'touchmove', _this._onTouchMove);
+						_on(document, 'touchend', _this._onDrop);
+						_on(document, 'touchcancel', _this._onDrop);
+
+						if (options.supportPointer) {
+							_on(document, 'pointermove', _this._onTouchMove);
+							_on(document, 'pointerup', _this._onDrop);
+						}
+					} else {
+						// Old brwoser
+						_on(document, 'mousemove', _this._onTouchMove);
+						_on(document, 'mouseup', _this._onDrop);
 					}
-					_dispatchEvent(_this, rootEl, 'clone', dragEl);
-				});
 
-				!fallback && _toggleClass(dragEl, options.dragClass, true);
-
-				// Set proper drop events
-				if (fallback) {
-					ignoreNextClick = true;
 					_this._loopId = setInterval(_this._emulateDragOver, 50);
 				} else {
-					// Undo what was set in _prepareDragStart before drag started
-					_off(document, 'mouseup', _this._onDrop);
-					_off(document, 'touchend', _this._onDrop);
-					_off(document, 'touchcancel', _this._onDrop);
-					_off(document, 'pointercancel', _this._onDrop);
-
 					if (dataTransfer) {
 						dataTransfer.effectAllowed = 'move';
 						options.setData && options.setData.call(_this, dataTransfer, dragEl);
@@ -2313,20 +1991,18 @@ var Sortable = createCommonjsModule(function (module) {
 
 					_on(document, 'drop', _this);
 
-					// #1276 fix:
-					_css(dragEl, 'transform', 'translateZ(0)');
+					// #1143: Бывает элемент с IFrame внутри блокирует `drop`,
+					// поэтому если вызвался `mouseover`, значит надо отменять весь d'n'd.
+					// Breaking Chrome 62+
+					// _on(document, 'mouseover', _this);
+
+					_this._dragStartId = _nextTick(_this._dragStarted);
 				}
-
-				awaitingDragStarted = true;
-
-				_this._dragStartId = _nextTick(_this._dragStarted.bind(_this, fallback));
-				_on(document, 'selectstart', _this);
 			},
 
-			// Returns true - if no further action is needed (either inserted or another condition)
 			_onDragOver: function _onDragOver( /**Event*/evt) {
 				var el = this.el,
-				    target = evt.target,
+				    target,
 				    dragRect,
 				    targetRect,
 				    revert,
@@ -2334,233 +2010,157 @@ var Sortable = createCommonjsModule(function (module) {
 				    group = options.group,
 				    activeSortable = Sortable.active,
 				    isOwner = activeGroup === group,
-				    canSort = options.sort,
-				    _this = this;
-
-				if (_silent) return;
-
-				// IE event order fix
-				if (IE11OrLess && !evt.rootEl && !evt.artificialBubble && !_isTrueParentSortable(el, target)) {
-					return;
-				}
-
-				// Return invocation when no further action is needed in another sortable
-				function completed() {
-					if (activeSortable) {
-						// Set ghost class to new sortable's ghost class
-						_toggleClass(dragEl, putSortable ? putSortable.options.ghostClass : activeSortable.options.ghostClass, false);
-						_toggleClass(dragEl, options.ghostClass, true);
-					}
-
-					if (putSortable !== _this && _this !== Sortable.active) {
-						putSortable = _this;
-					} else if (_this === Sortable.active) {
-						putSortable = null;
-					}
-
-					// Null lastTarget if it is not inside a previously swapped element
-					if (target === dragEl && !dragEl.animated || target === el && !target.animated) {
-						lastTarget = null;
-					}
-					// no bubbling and not fallback
-					if (!options.dragoverBubble && !evt.rootEl && target !== document) {
-						_this._handleAutoScroll(evt);
-						dragEl.parentNode[expando]._computeIsAligned(evt);
-					}
-
-					!options.dragoverBubble && evt.stopPropagation && evt.stopPropagation();
-
-					return true;
-				}
-
-				// Call when dragEl has been inserted
-				function changed() {
-					_dispatchEvent(_this, rootEl, 'change', target, el, rootEl, oldIndex, _index(dragEl, options.draggable), evt);
-				}
+				    isMovingBetweenSortable = false,
+				    canSort = options.sort;
 
 				if (evt.preventDefault !== void 0) {
-					evt.cancelable && evt.preventDefault();
+					evt.preventDefault();
+					!options.dragoverBubble && evt.stopPropagation();
+				}
+
+				if (dragEl.animated) {
+					return;
 				}
 
 				moved = true;
 
-				target = _closest(target, options.draggable, el, true);
-
-				// target is dragEl or target is animated
-				if (!!_closest(evt.target, null, dragEl, true) || target.animated) {
-					return completed();
-				}
-
-				if (target !== dragEl) {
-					ignoreNextClick = false;
-				}
-
 				if (activeSortable && !options.disabled && (isOwner ? canSort || (revert = !rootEl.contains(dragEl)) // Reverting item into the original list
-				: putSortable === this || (this.lastPutMode = activeGroup.checkPull(this, activeSortable, dragEl, evt)) && group.checkPut(this, activeSortable, dragEl, evt))) {
-					var axis = this._getDirection(evt, target);
+				: putSortable === this || (activeSortable.lastPullMode = activeGroup.checkPull(this, activeSortable, dragEl, evt)) && group.checkPut(this, activeSortable, dragEl, evt)) && (evt.rootEl === void 0 || evt.rootEl === this.el) // touch fallback
+				) {
+						// Smart auto-scrolling
+						_autoScroll(evt, options, this.el);
 
-					dragRect = _getRect(dragEl);
-
-					if (revert) {
-						this._hideClone();
-						parentEl = rootEl; // actualization
-
-						if (nextEl) {
-							rootEl.insertBefore(dragEl, nextEl);
-						} else {
-							rootEl.appendChild(dragEl);
+						if (_silent) {
+							return;
 						}
 
-						return completed();
-					}
+						target = _closest(evt.target, options.draggable, el);
+						dragRect = dragEl.getBoundingClientRect();
 
-					if (el.children.length === 0 || el.children[0] === ghostEl || _ghostIsLast(evt, axis, el) && !dragEl.animated) {
-						//assign target only if condition is true
-						if (el.children.length !== 0 && el.children[0] !== ghostEl && el === evt.target) {
-							target = _lastChild(el);
+						if (putSortable !== this) {
+							putSortable = this;
+							isMovingBetweenSortable = true;
 						}
 
-						if (target) {
-							targetRect = _getRect(target);
-						}
+						if (revert) {
+							_cloneHide(activeSortable, true);
+							parentEl = rootEl; // actualization
 
-						if (isOwner) {
-							activeSortable._hideClone();
-						} else {
-							activeSortable._showClone(this);
-						}
-
-						if (_onMove(rootEl, el, dragEl, dragRect, target, targetRect, evt, !!target) !== false) {
-							el.appendChild(dragEl);
-							parentEl = el; // actualization
-							realDragElRect = null;
-
-							changed();
-							this._animate(dragRect, dragEl);
-							target && this._animate(targetRect, target);
-							return completed();
-						}
-					} else if (target && target !== dragEl && target.parentNode[expando] !== void 0 && target !== el) {
-						var direction = 0,
-						    targetBeforeFirstSwap,
-						    aligned = target.sortableMouseAligned,
-						    differentLevel = dragEl.parentNode !== el,
-						    scrolledPastTop = _isScrolledPast(target, axis === 'vertical' ? 'top' : 'left');
-
-						if (lastTarget !== target) {
-							lastMode = null;
-							targetBeforeFirstSwap = _getRect(target)[axis === 'vertical' ? 'top' : 'left'];
-							pastFirstInvertThresh = false;
-						}
-
-						// Reference: https://www.lucidchart.com/documents/view/10fa0e93-e362-4126-aca2-b709ee56bd8b/0
-						if (_isElInRowColumn(dragEl, target, axis) && aligned || differentLevel || scrolledPastTop || options.invertSwap || lastMode === 'insert' ||
-						// Needed, in the case that we are inside target and inserted because not aligned... aligned will stay false while inside
-						// and lastMode will change to 'insert', but we must swap
-						lastMode === 'swap') {
-							// New target that we will be inside
-							if (lastMode !== 'swap') {
-								isCircumstantialInvert = options.invertSwap || differentLevel || scrolling || scrolledPastTop;
+							if (cloneEl || nextEl) {
+								rootEl.insertBefore(dragEl, cloneEl || nextEl);
+							} else if (!canSort) {
+								rootEl.appendChild(dragEl);
 							}
 
-							direction = _getSwapDirection(evt, target, axis, options.swapThreshold, options.invertedSwapThreshold == null ? options.swapThreshold : options.invertedSwapThreshold, isCircumstantialInvert, lastTarget === target);
-							lastMode = 'swap';
-						} else {
-							// Insert at position
-							direction = _getInsertDirection(target, options);
-							lastMode = 'insert';
+							return;
 						}
-						if (direction === 0) return completed();
 
-						realDragElRect = null;
-						lastTarget = target;
-
-						lastDirection = direction;
-
-						targetRect = _getRect(target);
-
-						var nextSibling = target.nextElementSibling,
-						    after = false;
-
-						after = direction === 1;
-
-						var moveVector = _onMove(rootEl, el, dragEl, dragRect, target, targetRect, evt, after);
-
-						if (moveVector !== false) {
-							if (moveVector === 1 || moveVector === -1) {
-								after = moveVector === 1;
+						if (el.children.length === 0 || el.children[0] === ghostEl || el === evt.target && _ghostIsLast(el, evt)) {
+							//assign target only if condition is true
+							if (el.children.length !== 0 && el.children[0] !== ghostEl && el === evt.target) {
+								target = el.lastElementChild;
 							}
 
-							_silent = true;
-							setTimeout(_unsilent, 30);
+							if (target) {
+								if (target.animated) {
+									return;
+								}
 
-							if (isOwner) {
-								activeSortable._hideClone();
-							} else {
-								activeSortable._showClone(this);
+								targetRect = target.getBoundingClientRect();
 							}
 
-							if (after && !nextSibling) {
-								el.appendChild(dragEl);
-							} else {
-								target.parentNode.insertBefore(dragEl, after ? nextSibling : target);
+							_cloneHide(activeSortable, isOwner);
+
+							if (_onMove(rootEl, el, dragEl, dragRect, target, targetRect, evt) !== false) {
+								if (!dragEl.contains(el)) {
+									el.appendChild(dragEl);
+									parentEl = el; // actualization
+								}
+
+								this._animate(dragRect, dragEl);
+								target && this._animate(targetRect, target);
+							}
+						} else if (target && !target.animated && target !== dragEl && target.parentNode[expando] !== void 0) {
+							if (lastEl !== target) {
+								lastEl = target;
+								lastCSS = _css(target);
+								lastParentCSS = _css(target.parentNode);
 							}
 
-							parentEl = dragEl.parentNode; // actualization
+							targetRect = target.getBoundingClientRect();
 
-							// must be done before animation
-							if (targetBeforeFirstSwap !== undefined && !isCircumstantialInvert) {
-								targetMoveDistance = abs(targetBeforeFirstSwap - _getRect(target)[axis === 'vertical' ? 'top' : 'left']);
+							var width = targetRect.right - targetRect.left,
+							    height = targetRect.bottom - targetRect.top,
+							    floating = R_FLOAT.test(lastCSS.cssFloat + lastCSS.display) || lastParentCSS.display == 'flex' && lastParentCSS['flex-direction'].indexOf('row') === 0,
+							    isWide = target.offsetWidth > dragEl.offsetWidth,
+							    isLong = target.offsetHeight > dragEl.offsetHeight,
+							    halfway = (floating ? (evt.clientX - targetRect.left) / width : (evt.clientY - targetRect.top) / height) > 0.5,
+							    nextSibling = target.nextElementSibling,
+							    after = false;
+
+							if (floating) {
+								var elTop = dragEl.offsetTop,
+								    tgTop = target.offsetTop;
+
+								if (elTop === tgTop) {
+									after = target.previousElementSibling === dragEl && !isWide || halfway && isWide;
+								} else if (target.previousElementSibling === dragEl || dragEl.previousElementSibling === target) {
+									after = (evt.clientY - targetRect.top) / height > 0.5;
+								} else {
+									after = tgTop > elTop;
+								}
+							} else if (!isMovingBetweenSortable) {
+								after = nextSibling !== dragEl && !isLong || halfway && isLong;
 							}
-							changed();
-							!differentLevel && this._animate(targetRect, target);
-							this._animate(dragRect, dragEl);
 
-							return completed();
+							var moveVector = _onMove(rootEl, el, dragEl, dragRect, target, targetRect, evt, after);
+
+							if (moveVector !== false) {
+								if (moveVector === 1 || moveVector === -1) {
+									after = moveVector === 1;
+								}
+
+								_silent = true;
+								setTimeout(_unsilent, 30);
+
+								_cloneHide(activeSortable, isOwner);
+
+								if (!dragEl.contains(el)) {
+									if (after && !nextSibling) {
+										el.appendChild(dragEl);
+									} else {
+										target.parentNode.insertBefore(dragEl, after ? nextSibling : target);
+									}
+								}
+
+								parentEl = dragEl.parentNode; // actualization
+
+								this._animate(dragRect, dragEl);
+								this._animate(targetRect, target);
+							}
 						}
 					}
-
-					if (el.contains(dragEl)) {
-						return completed();
-					}
-				}
-
-				if (IE11OrLess && !evt.rootEl) {
-					_artificalBubble(el, evt, '_onDragOver');
-				}
-
-				return false;
 			},
 
 			_animate: function _animate(prevRect, target) {
 				var ms = this.options.animation;
 
 				if (ms) {
-					var currentRect = _getRect(target);
-
-					if (target === dragEl) {
-						realDragElRect = currentRect;
-					}
+					var currentRect = target.getBoundingClientRect();
 
 					if (prevRect.nodeType === 1) {
-						prevRect = _getRect(prevRect);
+						prevRect = prevRect.getBoundingClientRect();
 					}
 
-					// Check if actually moving position
-					if (prevRect.left + prevRect.width / 2 !== currentRect.left + currentRect.width / 2 || prevRect.top + prevRect.height / 2 !== currentRect.top + currentRect.height / 2) {
-						var matrix = _matrix(this.el),
-						    scaleX = matrix && matrix.a,
-						    scaleY = matrix && matrix.d;
+					_css(target, 'transition', 'none');
+					_css(target, 'transform', 'translate3d(' + (prevRect.left - currentRect.left) + 'px,' + (prevRect.top - currentRect.top) + 'px,0)');
 
-						_css(target, 'transition', 'none');
-						_css(target, 'transform', 'translate3d(' + (prevRect.left - currentRect.left) / (scaleX ? scaleX : 1) + 'px,' + (prevRect.top - currentRect.top) / (scaleY ? scaleY : 1) + 'px,0)');
+					target.offsetWidth; // repaint
 
-						forRepaintDummy = target.offsetWidth; // repaint
-						_css(target, 'transition', 'transform ' + ms + 'ms' + (this.options.easing ? ' ' + this.options.easing : ''));
-						_css(target, 'transform', 'translate3d(0,0,0)');
-					}
+					_css(target, 'transition', 'all ' + ms + 'ms');
+					_css(target, 'transform', 'translate3d(0,0,0)');
 
-					typeof target.animated === 'number' && clearTimeout(target.animated);
+					clearTimeout(target.animated);
 					target.animated = setTimeout(function () {
 						_css(target, 'transition', '');
 						_css(target, 'transform', '');
@@ -2579,50 +2179,40 @@ var Sortable = createCommonjsModule(function (module) {
 				_off(ownerDocument, 'pointerup', this._onDrop);
 				_off(ownerDocument, 'touchcancel', this._onDrop);
 				_off(ownerDocument, 'pointercancel', this._onDrop);
-				_off(document, 'selectstart', this);
+				_off(ownerDocument, 'selectstart', this);
 			},
 
 			_onDrop: function _onDrop( /**Event*/evt) {
 				var el = this.el,
 				    options = this.options;
 
-				awaitingDragStarted = false;
-				scrolling = false;
-				isCircumstantialInvert = false;
-				pastFirstInvertThresh = false;
-
 				clearInterval(this._loopId);
-
-				clearInterval(pointerElemChangedInterval);
-				_clearAutoScrolls();
-				_cancelThrottle();
-
+				clearInterval(autoScroll.pid);
 				clearTimeout(this._dragStartTimer);
 
 				_cancelNextTick(this._cloneId);
 				_cancelNextTick(this._dragStartId);
 
 				// Unbind events
+				_off(document, 'mouseover', this);
 				_off(document, 'mousemove', this._onTouchMove);
 
 				if (this.nativeDraggable) {
 					_off(document, 'drop', this);
 					_off(el, 'dragstart', this._onDragStart);
-					_off(document, 'dragover', this._handleAutoScroll);
-					_off(document, 'dragover', _checkAlignment);
 				}
 
 				this._offUpEvents();
 
 				if (evt) {
 					if (moved) {
-						evt.cancelable && evt.preventDefault();
+						evt.preventDefault();
 						!options.dropBubble && evt.stopPropagation();
 					}
 
 					ghostEl && ghostEl.parentNode && ghostEl.parentNode.removeChild(ghostEl);
 
-					if (rootEl === parentEl || putSortable && putSortable.lastPutMode !== 'clone') {
+					if (rootEl === parentEl || Sortable.active.lastPullMode !== 'clone') {
 						// Remove clone
 						cloneEl && cloneEl.parentNode && cloneEl.parentNode.removeChild(cloneEl);
 					}
@@ -2636,28 +2226,26 @@ var Sortable = createCommonjsModule(function (module) {
 						dragEl.style['will-change'] = '';
 
 						// Remove class's
-						_toggleClass(dragEl, putSortable ? putSortable.options.ghostClass : this.options.ghostClass, false);
+						_toggleClass(dragEl, this.options.ghostClass, false);
 						_toggleClass(dragEl, this.options.chosenClass, false);
 
 						// Drag stop event
-						_dispatchEvent(this, rootEl, 'unchoose', dragEl, parentEl, rootEl, oldIndex, null, evt);
+						_dispatchEvent(this, rootEl, 'unchoose', dragEl, parentEl, rootEl, oldIndex);
 
 						if (rootEl !== parentEl) {
 							newIndex = _index(dragEl, options.draggable);
 
 							if (newIndex >= 0) {
 								// Add event
-								_dispatchEvent(null, parentEl, 'add', dragEl, parentEl, rootEl, oldIndex, newIndex, evt);
+								_dispatchEvent(null, parentEl, 'add', dragEl, parentEl, rootEl, oldIndex, newIndex);
 
 								// Remove event
-								_dispatchEvent(this, rootEl, 'remove', dragEl, parentEl, rootEl, oldIndex, newIndex, evt);
+								_dispatchEvent(this, rootEl, 'remove', dragEl, parentEl, rootEl, oldIndex, newIndex);
 
 								// drag from one list and drop into another
-								_dispatchEvent(null, parentEl, 'sort', dragEl, parentEl, rootEl, oldIndex, newIndex, evt);
-								_dispatchEvent(this, rootEl, 'sort', dragEl, parentEl, rootEl, oldIndex, newIndex, evt);
+								_dispatchEvent(null, parentEl, 'sort', dragEl, parentEl, rootEl, oldIndex, newIndex);
+								_dispatchEvent(this, rootEl, 'sort', dragEl, parentEl, rootEl, oldIndex, newIndex);
 							}
-
-							putSortable && putSortable.save();
 						} else {
 							if (dragEl.nextSibling !== nextEl) {
 								// Get the index of the dragged element within its parent
@@ -2665,8 +2253,8 @@ var Sortable = createCommonjsModule(function (module) {
 
 								if (newIndex >= 0) {
 									// drag & drop within the same list
-									_dispatchEvent(this, rootEl, 'update', dragEl, parentEl, rootEl, oldIndex, newIndex, evt);
-									_dispatchEvent(this, rootEl, 'sort', dragEl, parentEl, rootEl, oldIndex, newIndex, evt);
+									_dispatchEvent(this, rootEl, 'update', dragEl, parentEl, rootEl, oldIndex, newIndex);
+									_dispatchEvent(this, rootEl, 'sort', dragEl, parentEl, rootEl, oldIndex, newIndex);
 								}
 							}
 						}
@@ -2677,23 +2265,23 @@ var Sortable = createCommonjsModule(function (module) {
 								newIndex = oldIndex;
 							}
 
-							_dispatchEvent(this, rootEl, 'end', dragEl, parentEl, rootEl, oldIndex, newIndex, evt);
+							_dispatchEvent(this, rootEl, 'end', dragEl, parentEl, rootEl, oldIndex, newIndex);
 
 							// Save sorting
 							this.save();
 						}
 					}
 				}
+
 				this._nulling();
 			},
 
 			_nulling: function _nulling() {
-				rootEl = dragEl = parentEl = ghostEl = nextEl = cloneEl = lastDownEl = scrollEl = scrollParentEl = autoScrolls.length = pointerElemChangedInterval = lastPointerElemX = lastPointerElemY = tapEvt = touchEvt = moved = newIndex = oldIndex = lastTarget = lastDirection = forRepaintDummy = realDragElRect = putSortable = activeGroup = Sortable.active = null;
+				rootEl = dragEl = parentEl = ghostEl = nextEl = cloneEl = lastDownEl = scrollEl = scrollParentEl = tapEvt = touchEvt = moved = newIndex = lastEl = lastCSS = putSortable = activeGroup = Sortable.active = null;
 
 				savedInputChecked.forEach(function (el) {
 					el.checked = true;
 				});
-
 				savedInputChecked.length = 0;
 			},
 
@@ -2704,12 +2292,16 @@ var Sortable = createCommonjsModule(function (module) {
 						this._onDrop(evt);
 						break;
 
-					case 'dragenter':
 					case 'dragover':
+					case 'dragenter':
 						if (dragEl) {
 							this._onDragOver(evt);
 							_globalDragOver(evt);
 						}
+						break;
+
+					case 'mouseover':
+						this._onDrop(evt);
 						break;
 
 					case 'selectstart':
@@ -2732,7 +2324,7 @@ var Sortable = createCommonjsModule(function (module) {
 
 				for (; i < n; i++) {
 					el = children[i];
-					if (_closest(el, options.draggable, this.el, false)) {
+					if (_closest(el, options.draggable, this.el)) {
 						order.push(el.getAttribute(options.dataIdAttr) || _generateId(el));
 					}
 				}
@@ -2751,7 +2343,7 @@ var Sortable = createCommonjsModule(function (module) {
 				this.toArray().forEach(function (id, i) {
 					var el = rootEl.children[i];
 
-					if (_closest(el, this.options.draggable, rootEl, false)) {
+					if (_closest(el, this.options.draggable, rootEl)) {
 						items[id] = el;
 					}
 				}, this);
@@ -2769,7 +2361,7 @@ var Sortable = createCommonjsModule(function (module) {
     */
 			save: function save() {
 				var store = this.options.store;
-				store && store.set && store.set(this);
+				store && store.set(this);
 			},
 
 			/**
@@ -2779,7 +2371,7 @@ var Sortable = createCommonjsModule(function (module) {
     * @returns {HTMLElement|null}
     */
 			closest: function closest(el, selector) {
-				return _closest(el, selector || this.options.draggable, this.el, false);
+				return _closest(el, selector || this.options.draggable, this.el);
 			},
 
 			/**
@@ -2818,63 +2410,51 @@ var Sortable = createCommonjsModule(function (module) {
 					_off(el, 'dragover', this);
 					_off(el, 'dragenter', this);
 				}
+
 				// Remove draggable attributes
 				Array.prototype.forEach.call(el.querySelectorAll('[draggable]'), function (el) {
 					el.removeAttribute('draggable');
 				});
 
+				touchDragOverListeners.splice(touchDragOverListeners.indexOf(this._onDragOver), 1);
+
 				this._onDrop();
 
-				sortables.splice(sortables.indexOf(this.el), 1);
-
 				this.el = el = null;
-			},
-
-			_hideClone: function _hideClone() {
-				if (!cloneEl.cloneHidden) {
-					_css(cloneEl, 'display', 'none');
-					cloneEl.cloneHidden = true;
-					if (cloneEl.parentNode && this.options.removeCloneOnHide) {
-						cloneEl.parentNode.removeChild(cloneEl);
-					}
-				}
-			},
-
-			_showClone: function _showClone(putSortable) {
-				if (putSortable.lastPutMode !== 'clone') {
-					this._hideClone();
-					return;
-				}
-
-				if (cloneEl.cloneHidden) {
-					// show clone at dragEl or original position
-					if (rootEl.contains(dragEl) && !this.options.group.revertClone) {
-						rootEl.insertBefore(cloneEl, dragEl);
-					} else if (nextEl) {
-						rootEl.insertBefore(cloneEl, nextEl);
-					} else {
-						rootEl.appendChild(cloneEl);
-					}
-
-					if (this.options.group.revertClone) {
-						this._animate(dragEl, cloneEl);
-					}
-					_css(cloneEl, 'display', '');
-					cloneEl.cloneHidden = false;
-				}
 			}
 		};
 
-		function _closest( /**HTMLElement*/el, /**String*/selector, /**HTMLElement*/ctx, includeCTX) {
+		function _cloneHide(sortable, state) {
+			if (sortable.lastPullMode !== 'clone') {
+				state = true;
+			}
+
+			if (cloneEl && cloneEl.state !== state) {
+				_css(cloneEl, 'display', state ? 'none' : '');
+
+				if (!state) {
+					if (cloneEl.state) {
+						if (sortable.options.group.revertClone) {
+							rootEl.insertBefore(cloneEl, nextEl);
+							sortable._animate(dragEl, cloneEl);
+						} else {
+							rootEl.insertBefore(cloneEl, dragEl);
+						}
+					}
+				}
+
+				cloneEl.state = state;
+			}
+		}
+
+		function _closest( /**HTMLElement*/el, /**String*/selector, /**HTMLElement*/ctx) {
 			if (el) {
 				ctx = ctx || document;
 
 				do {
-					if (selector === '>*' && el.parentNode === ctx || _matches(el, selector) || includeCTX && el === ctx) {
+					if (selector === '>*' && el.parentNode === ctx || _matches(el, selector)) {
 						return el;
 					}
-
-					if (el === ctx) break;
 					/* jshint boss:true */
 				} while (el = _getParentOrHost(el));
 			}
@@ -2883,14 +2463,16 @@ var Sortable = createCommonjsModule(function (module) {
 		}
 
 		function _getParentOrHost(el) {
-			return el.host && el !== document && el.host.nodeType ? el.host : el.parentNode;
+			var parent = el.host;
+
+			return parent && parent.nodeType ? parent : el.parentNode;
 		}
 
 		function _globalDragOver( /**Event*/evt) {
 			if (evt.dataTransfer) {
 				evt.dataTransfer.dropEffect = 'move';
 			}
-			evt.cancelable && evt.preventDefault();
+			evt.preventDefault();
 		}
 
 		function _on(el, event, fn) {
@@ -2902,7 +2484,7 @@ var Sortable = createCommonjsModule(function (module) {
 		}
 
 		function _toggleClass(el, name, state) {
-			if (el && name) {
+			if (el) {
 				if (el.classList) {
 					el.classList[state ? 'add' : 'remove'](name);
 				} else {
@@ -2925,32 +2507,12 @@ var Sortable = createCommonjsModule(function (module) {
 
 					return prop === void 0 ? val : val[prop];
 				} else {
-					if (!(prop in style) && prop.indexOf('webkit') === -1) {
+					if (!(prop in style)) {
 						prop = '-webkit-' + prop;
 					}
 
 					style[prop] = val + (typeof val === 'string' ? '' : 'px');
 				}
-			}
-		}
-
-		function _matrix(el) {
-			var appliedTransforms = '';
-			do {
-				var transform = _css(el, 'transform');
-
-				if (transform && transform !== 'none') {
-					appliedTransforms = transform + ' ' + appliedTransforms;
-				}
-				/* jshint boss:true */
-			} while (el = el.parentNode);
-
-			if (window.DOMMatrix) {
-				return new DOMMatrix(appliedTransforms);
-			} else if (window.WebKitCSSMatrix) {
-				return new WebKitCSSMatrix(appliedTransforms);
-			} else if (window.CSSMatrix) {
-				return new CSSMatrix(appliedTransforms);
 			}
 		}
 
@@ -2972,21 +2534,14 @@ var Sortable = createCommonjsModule(function (module) {
 			return [];
 		}
 
-		function _dispatchEvent(sortable, rootEl, name, targetEl, toEl, fromEl, startIndex, newIndex, originalEvt) {
+		function _dispatchEvent(sortable, rootEl, name, targetEl, toEl, fromEl, startIndex, newIndex) {
 			sortable = sortable || rootEl[expando];
-			var evt,
+
+			var evt = document.createEvent('Event'),
 			    options = sortable.options,
 			    onName = 'on' + name.charAt(0).toUpperCase() + name.substr(1);
-			// Support for new CustomEvent feature
-			if (window.CustomEvent && !IE11OrLess && !Edge) {
-				evt = new CustomEvent(name, {
-					bubbles: true,
-					cancelable: true
-				});
-			} else {
-				evt = document.createEvent('Event');
-				evt.initEvent(name, true, true);
-			}
+
+			evt.initEvent(name, true, true);
 
 			evt.to = toEl || rootEl;
 			evt.from = fromEl || rootEl;
@@ -2996,11 +2551,7 @@ var Sortable = createCommonjsModule(function (module) {
 			evt.oldIndex = startIndex;
 			evt.newIndex = newIndex;
 
-			evt.originalEvent = originalEvt;
-
-			if (rootEl) {
-				rootEl.dispatchEvent(evt);
-			}
+			rootEl.dispatchEvent(evt);
 
 			if (options[onName]) {
 				options[onName].call(sortable, evt);
@@ -3012,26 +2563,17 @@ var Sortable = createCommonjsModule(function (module) {
 			    sortable = fromEl[expando],
 			    onMoveFn = sortable.options.onMove,
 			    retVal;
-			// Support for new CustomEvent feature
-			if (window.CustomEvent && !IE11OrLess && !Edge) {
-				evt = new CustomEvent('move', {
-					bubbles: true,
-					cancelable: true
-				});
-			} else {
-				evt = document.createEvent('Event');
-				evt.initEvent('move', true, true);
-			}
+
+			evt = document.createEvent('Event');
+			evt.initEvent('move', true, true);
 
 			evt.to = toEl;
 			evt.from = fromEl;
 			evt.dragged = dragEl;
 			evt.draggedRect = dragRect;
 			evt.related = targetEl || toEl;
-			evt.relatedRect = targetRect || _getRect(toEl);
+			evt.relatedRect = targetRect || toEl.getBoundingClientRect();
 			evt.willInsertAfter = willInsertAfter;
-
-			evt.originalEvent = originalEvt;
 
 			fromEl.dispatchEvent(evt);
 
@@ -3050,121 +2592,14 @@ var Sortable = createCommonjsModule(function (module) {
 			_silent = false;
 		}
 
-		/**
-   * Gets nth child of el, ignoring hidden children, sortable's elements (does not ignore clone if it's visible)
-   * and non-draggable elements
-   * @param  {HTMLElement} el       The parent element
-   * @param  {Number} childNum      The index of the child
-   * @param  {Object} options       Parent Sortable's options
-   * @return {HTMLElement}          The child at index childNum, or null if not found
-   */
-		function _getChild(el, childNum, options) {
-			var currentChild = 0,
-			    i = 0,
-			    children = el.children;
+		/** @returns {HTMLElement|false} */
+		function _ghostIsLast(el, evt) {
+			var lastEl = el.lastElementChild,
+			    rect = lastEl.getBoundingClientRect();
 
-			while (i < children.length) {
-				if (children[i].style.display !== 'none' && children[i] !== ghostEl && children[i] !== dragEl && _closest(children[i], options.draggable, el, false)) {
-					if (currentChild === childNum) {
-						return children[i];
-					}
-					currentChild++;
-				}
-
-				i++;
-			}
-			return null;
-		}
-
-		/**
-   * Gets the last child in the el, ignoring ghostEl
-   * @param  {HTMLElement} el       Parent element
-   * @return {HTMLElement}          The last child, ignoring ghostEl
-   */
-		function _lastChild(el) {
-			var last = el.lastElementChild;
-
-			if (last === ghostEl) {
-				last = el.children[el.childElementCount - 2];
-			}
-
-			return last || null;
-		}
-
-		function _ghostIsLast(evt, axis, el) {
-			var elRect = _getRect(_lastChild(el)),
-			    mouseOnAxis = axis === 'vertical' ? evt.clientY : evt.clientX,
-			    mouseOnOppAxis = axis === 'vertical' ? evt.clientX : evt.clientY,
-			    targetS2 = axis === 'vertical' ? elRect.bottom : elRect.right,
-			    targetS1Opp = axis === 'vertical' ? elRect.left : elRect.top,
-			    targetS2Opp = axis === 'vertical' ? elRect.right : elRect.bottom;
-
-			return mouseOnOppAxis > targetS1Opp && mouseOnOppAxis < targetS2Opp && mouseOnAxis > targetS2;
-		}
-
-		function _getSwapDirection(evt, target, axis, swapThreshold, invertedSwapThreshold, invertSwap, isLastTarget) {
-			var targetRect = _getRect(target),
-			    mouseOnAxis = axis === 'vertical' ? evt.clientY : evt.clientX,
-			    targetLength = axis === 'vertical' ? targetRect.height : targetRect.width,
-			    targetS1 = axis === 'vertical' ? targetRect.top : targetRect.left,
-			    targetS2 = axis === 'vertical' ? targetRect.bottom : targetRect.right,
-			    dragRect = _getRect(dragEl),
-			    invert = false;
-
-			if (!invertSwap) {
-				// Never invert or create dragEl shadow when target movemenet causes mouse to move past the end of regular swapThreshold
-				if (isLastTarget && targetMoveDistance < targetLength * swapThreshold) {
-					// multiplied only by swapThreshold because mouse will already be inside target by (1 - threshold) * targetLength / 2
-					// check if past first invert threshold on side opposite of lastDirection
-					if (!pastFirstInvertThresh && (lastDirection === 1 ? mouseOnAxis > targetS1 + targetLength * invertedSwapThreshold / 2 : mouseOnAxis < targetS2 - targetLength * invertedSwapThreshold / 2)) {
-						// past first invert threshold, do not restrict inverted threshold to dragEl shadow
-						pastFirstInvertThresh = true;
-					}
-
-					if (!pastFirstInvertThresh) {
-						if (lastDirection === 1 ? mouseOnAxis < targetS1 + targetMoveDistance // over dragEl shadow
-						: mouseOnAxis > targetS2 - targetMoveDistance) {
-							return lastDirection * -1;
-						}
-					} else {
-						invert = true;
-					}
-				} else {
-					// Regular
-					if (mouseOnAxis > targetS1 + targetLength * (1 - swapThreshold) / 2 && mouseOnAxis < targetS2 - targetLength * (1 - swapThreshold) / 2) {
-						return mouseOnAxis > targetS1 + targetLength / 2 ? -1 : 1;
-					}
-				}
-			}
-
-			invert = invert || invertSwap;
-
-			if (invert) {
-				// Invert of regular
-				if (mouseOnAxis < targetS1 + targetLength * invertedSwapThreshold / 2 || mouseOnAxis > targetS2 - targetLength * invertedSwapThreshold / 2) {
-					return mouseOnAxis > targetS1 + targetLength / 2 ? 1 : -1;
-				}
-			}
-
-			return 0;
-		}
-
-		/**
-   * Gets the direction dragEl must be swapped relative to target in order to make it
-   * seem that dragEl has been "inserted" into that element's position
-   * @param  {HTMLElement} target       The target whose position dragEl is being inserted at
-   * @param  {Object} options           options of the parent sortable
-   * @return {Number}                   Direction dragEl must be swapped
-   */
-		function _getInsertDirection(target, options) {
-			var dragElIndex = _index(dragEl, options.draggable),
-			    targetIndex = _index(target, options.draggable);
-
-			if (dragElIndex < targetIndex) {
-				return 1;
-			} else {
-				return -1;
-			}
+			// 5 — min delta
+			// abs — нельзя добавлять, а то глюки при наведении сверху
+			return evt.clientY - (rect.top + rect.height) > 5 || evt.clientX - (rect.left + rect.width) > 5;
 		}
 
 		/**
@@ -3200,7 +2635,7 @@ var Sortable = createCommonjsModule(function (module) {
 			}
 
 			while (el && (el = el.previousElementSibling)) {
-				if (el.nodeName.toUpperCase() !== 'TEMPLATE' && el !== cloneEl) {
+				if (el.nodeName.toUpperCase() !== 'TEMPLATE' && (selector === '>*' || _matches(el, selector))) {
 					index++;
 				}
 			}
@@ -3210,45 +2645,36 @@ var Sortable = createCommonjsModule(function (module) {
 
 		function _matches( /**HTMLElement*/el, /**String*/selector) {
 			if (el) {
-				try {
-					if (el.matches) {
-						return el.matches(selector);
-					} else if (el.msMatchesSelector) {
-						return el.msMatchesSelector(selector);
-					} else if (el.webkitMatchesSelector) {
-						return el.webkitMatchesSelector(selector);
-					}
-				} catch (_) {
-					return false;
-				}
+				selector = selector.split('.');
+
+				var tag = selector.shift().toUpperCase(),
+				    re = new RegExp('\\s(' + selector.join('|') + ')(?=\\s)', 'g');
+
+				return (tag === '' || el.nodeName.toUpperCase() == tag) && (!selector.length || ((' ' + el.className + ' ').match(re) || []).length == selector.length);
 			}
 
 			return false;
 		}
 
-		var _throttleTimeout;
 		function _throttle(callback, ms) {
-			return function () {
-				if (!_throttleTimeout) {
-					var args = arguments,
-					    _this = this;
+			var args, _this;
 
-					_throttleTimeout = setTimeout(function () {
+			return function () {
+				if (args === void 0) {
+					args = arguments;
+					_this = this;
+
+					setTimeout(function () {
 						if (args.length === 1) {
 							callback.call(_this, args[0]);
 						} else {
 							callback.apply(_this, args);
 						}
 
-						_throttleTimeout = void 0;
+						args = void 0;
 					}, ms);
 				}
 			};
-		}
-
-		function _cancelThrottle() {
-			clearTimeout(_throttleTimeout);
-			_throttleTimeout = void 0;
 		}
 
 		function _extend(dst, src) {
@@ -3274,8 +2700,6 @@ var Sortable = createCommonjsModule(function (module) {
 		}
 
 		function _saveInputCheckedState(root) {
-			savedInputChecked.length = 0;
-
 			var inputs = root.getElementsByTagName('input');
 			var idx = inputs.length;
 
@@ -3293,120 +2717,9 @@ var Sortable = createCommonjsModule(function (module) {
 			return clearTimeout(id);
 		}
 
-		/**
-   * Returns the "bounding client rect" of given element
-   * @param  {HTMLElement} el                The element whose boundingClientRect is wanted
-   * @param  {[HTMLElement]} container       the parent the element will be placed in
-   * @param  {[Boolean]} adjustForTransform  Whether the rect should compensate for parent's transform
-   * (used for fixed positioning on el)
-   * @return {Object}                        The boundingClientRect of el
-   */
-		function _getRect(el, container, adjustForTransform) {
-			if (!el.getBoundingClientRect && el !== win) return;
-
-			var elRect, top, left, bottom, right, height, width;
-
-			if (el !== win) {
-				elRect = el.getBoundingClientRect();
-				top = elRect.top;
-				left = elRect.left;
-				bottom = elRect.bottom;
-				right = elRect.right;
-				height = elRect.height;
-				width = elRect.width;
-			} else {
-				top = 0;
-				left = 0;
-				bottom = window.innerHeight;
-				right = window.innerWidth;
-				height = window.innerHeight;
-				width = window.innerWidth;
-			}
-
-			if (adjustForTransform && el !== win) {
-				// Adjust for translate()
-				container = container || el.parentNode;
-
-				// solves #1123 (see: https://stackoverflow.com/a/37953806/6088312)
-				// Not needed on <= IE11
-				if (!IE11OrLess) {
-					do {
-						if (container && container.getBoundingClientRect && _css(container, 'transform') !== 'none') {
-							var containerRect = container.getBoundingClientRect();
-
-							// Set relative to edges of padding box of container
-							top -= containerRect.top + parseInt(_css(container, 'border-top-width'));
-							left -= containerRect.left + parseInt(_css(container, 'border-left-width'));
-							bottom = top + elRect.height;
-							right = left + elRect.width;
-
-							break;
-						}
-						/* jshint boss:true */
-					} while (container = container.parentNode);
-				}
-
-				// Adjust for scale()
-				var matrix = _matrix(el),
-				    scaleX = matrix && matrix.a,
-				    scaleY = matrix && matrix.d;
-
-				if (matrix) {
-					top /= scaleY;
-					left /= scaleX;
-
-					width /= scaleX;
-					height /= scaleY;
-
-					bottom = top + height;
-					right = left + width;
-				}
-			}
-
-			return {
-				top: top,
-				left: left,
-				bottom: bottom,
-				right: right,
-				width: width,
-				height: height
-			};
-		}
-
-		/**
-   * Checks if a side of an element is scrolled past a side of it's parents
-   * @param  {HTMLElement}  el       The element who's side being scrolled out of view is in question
-   * @param  {String}       side     Side of the element in question ('top', 'left', 'right', 'bottom')
-   * @return {Boolean}               Whether the element is overflowing the viewport on the given side of it's parent
-   */
-		function _isScrolledPast(el, side) {
-			var parent = _getParentAutoScrollElement(parent, true),
-			    elSide = _getRect(el)[side];
-
-			/* jshint boss:true */
-			while (parent) {
-				var parentSide = _getRect(parent)[side],
-				    visible;
-
-				if (side === 'top' || side === 'left') {
-					visible = elSide >= parentSide;
-				} else {
-					visible = elSide <= parentSide;
-				}
-
-				if (!visible) return true;
-
-				if (parent === win) break;
-
-				parent = _getParentAutoScrollElement(parent, false);
-			}
-
-			return false;
-		}
-
 		// Fixed #973:
 		_on(document, 'touchmove', function (evt) {
-			if ((Sortable.active || awaitingDragStarted) && evt.cancelable) {
+			if (Sortable.active) {
 				evt.preventDefault();
 			}
 		});
@@ -3418,7 +2731,7 @@ var Sortable = createCommonjsModule(function (module) {
 			css: _css,
 			find: _find,
 			is: function is(el, selector) {
-				return !!_closest(el, selector, el, false);
+				return !!_closest(el, selector, el);
 			},
 			extend: _extend,
 			throttle: _throttle,
@@ -3427,9 +2740,7 @@ var Sortable = createCommonjsModule(function (module) {
 			clone: _clone,
 			index: _index,
 			nextTick: _nextTick,
-			cancelNextTick: _cancelNextTick,
-			detectDirection: _detectDirection,
-			getChild: _getChild
+			cancelNextTick: _cancelNextTick
 		};
 
 		/**
@@ -3442,7 +2753,7 @@ var Sortable = createCommonjsModule(function (module) {
 		};
 
 		// Export
-		Sortable.version = '1.8.1';
+		Sortable.version = '1.7.0';
 		return Sortable;
 	});
 });
@@ -4929,7 +4240,6 @@ var breadcrumbs = (function (data) {
   }
 });
 
-
 /* Global Footer
 /* ========================================================================== */
 
@@ -4946,7 +4256,6 @@ var createFooter = (function (data) {
 	var $footerSocial = social(data.social, prefix);
 	var $footerBreadcrumb = breadcrumbs(data);
 
-
 	var $footer = $assign('footer', {
 		class: prefix + ' ' + (data.hideMenus ? 'skinny-footer' : ''),
 		role: 'navigation',
@@ -4956,7 +4265,6 @@ var createFooter = (function (data) {
 	/* Append Footer Components
  /* ================================================================== */
 	$assign('div', { class: prefix + '-section--0' }, $footerBreadcrumb), $assign('div', { class: prefix + '--wrapper' }, $assign('div', { class: prefix + '-section--1 ' + (data.hideMenus ? 'hidden' : '') }, $footerBrand, $footerSocial), $assign('div', { class: prefix + '-section--2 ' + (data.hideMenus ? 'hidden' : '') }, $footerMenu), $assign('div', { class: prefix + '-section--3' }, $footerLanguage, $footerInfo)));
-
 
 	/* On DOMNodeInserted
  /* ====================================================================== */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-global-nav",
-  "version": "1.1.2",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,7 +10,7 @@
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "7.0.0"
       }
     },
     "@babel/core": {
@@ -19,20 +19,20 @@
       "integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.2.2",
-        "@babel/helpers": "^7.2.0",
-        "@babel/parser": "^7.2.2",
-        "@babel/template": "^7.2.2",
-        "@babel/traverse": "^7.2.2",
-        "@babel/types": "^7.2.2",
-        "convert-source-map": "^1.1.0",
-        "debug": "^4.1.0",
-        "json5": "^2.1.0",
-        "lodash": "^4.17.10",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.3.0",
+        "@babel/helpers": "7.3.1",
+        "@babel/parser": "7.3.1",
+        "@babel/template": "7.2.2",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.0",
+        "convert-source-map": "1.6.0",
+        "debug": "4.1.1",
+        "json5": "2.1.0",
+        "lodash": "4.17.11",
+        "resolve": "1.8.1",
+        "semver": "5.5.1",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "debug": {
@@ -41,7 +41,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "json5": {
@@ -50,7 +50,7 @@
           "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.0"
           }
         },
         "minimist": {
@@ -79,11 +79,11 @@
       "integrity": "sha512-dZTwMvTgWfhmibq4V9X+LMf6Bgl7zAodRn9PvcPdhlzFMbvUutx74dbEv7Atz3ToeEpevYEJtAwfxq/bDCzHWg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.3.0",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.10",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "@babel/types": "7.3.0",
+        "jsesc": "2.5.2",
+        "lodash": "4.17.11",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -106,9 +106,9 @@
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/template": "7.2.2",
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -117,7 +117,7 @@
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -126,7 +126,7 @@
       "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/helpers": {
@@ -135,9 +135,9 @@
       "integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.1.2",
-        "@babel/traverse": "^7.1.5",
-        "@babel/types": "^7.3.0"
+        "@babel/template": "7.2.2",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/highlight": {
@@ -146,9 +146,9 @@
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
+        "chalk": "2.4.1",
+        "esutils": "2.0.2",
+        "js-tokens": "4.0.0"
       },
       "dependencies": {
         "js-tokens": {
@@ -171,9 +171,9 @@
       "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.2.2",
-        "@babel/types": "^7.2.2"
+        "@babel/code-frame": "7.0.0",
+        "@babel/parser": "7.3.1",
+        "@babel/types": "7.3.0"
       }
     },
     "@babel/traverse": {
@@ -182,15 +182,15 @@
       "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.2.2",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/parser": "^7.2.3",
-        "@babel/types": "^7.2.2",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.10"
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.3.0",
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "@babel/parser": "7.3.1",
+        "@babel/types": "7.3.0",
+        "debug": "4.1.1",
+        "globals": "11.10.0",
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "debug": {
@@ -199,7 +199,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "globals": {
@@ -222,9 +222,9 @@
       "integrity": "sha512-QkFPw68QqWU1/RVPyBe8SO7lXbPfjtqAxRYQKpFpaB8yMq7X2qAqfwK5LKoQufEkSmO5NQ70O6Kc3Afk03RwXw==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.10",
-        "to-fast-properties": "^2.0.0"
+        "esutils": "2.0.2",
+        "lodash": "4.17.11",
+        "to-fast-properties": "2.0.0"
       },
       "dependencies": {
         "to-fast-properties": {
@@ -241,11 +241,11 @@
       "integrity": "sha512-ciiioYMLdo16ShmfHBXJBOFm3xPC4AuwO4xeRpFeHz7WK9PYsWCmigagG2XyzZpubK4a3qNKoUBDhbzHfa50LQ==",
       "dev": true,
       "requires": {
-        "acorn": "^5.0.3",
-        "css": "^2.2.1",
-        "normalize-path": "^2.1.1",
-        "source-map": "^0.6.0",
-        "through2": "^2.0.3"
+        "acorn": "5.7.3",
+        "css": "2.2.4",
+        "normalize-path": "2.1.1",
+        "source-map": "0.6.1",
+        "through2": "2.0.3"
       }
     },
     "@gulp-sourcemaps/map-sources": {
@@ -254,8 +254,8 @@
       "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
       "dev": true,
       "requires": {
-        "normalize-path": "^2.0.1",
-        "through2": "^2.0.3"
+        "normalize-path": "2.1.1",
+        "through2": "2.0.3"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -264,8 +264,8 @@
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -304,9 +304,9 @@
       "integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "@types/unist": "*",
-        "@types/vfile-message": "*"
+        "@types/node": "10.12.20",
+        "@types/unist": "2.0.2",
+        "@types/vfile-message": "1.0.1"
       }
     },
     "@types/vfile-message": {
@@ -315,8 +315,8 @@
       "integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "@types/unist": "*"
+        "@types/node": "10.12.20",
+        "@types/unist": "2.0.2"
       }
     },
     "accepts": {
@@ -325,7 +325,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.18",
+        "mime-types": "2.1.20",
         "negotiator": "0.6.1"
       }
     },
@@ -353,10 +353,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "alphanum-sort": {
@@ -371,7 +371,7 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -392,8 +392,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -402,18 +402,18 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
-        "ansi-wrap": "^0.1.0"
+        "ansi-wrap": "0.1.0"
       }
     },
     "ansi-cyan": {
@@ -461,7 +461,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.3"
       }
     },
     "ansi-wrap": {
@@ -476,8 +476,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "append-buffer": {
@@ -486,7 +486,7 @@
       "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
       "dev": true,
       "requires": {
-        "buffer-equal": "^1.0.0"
+        "buffer-equal": "1.0.0"
       }
     },
     "application-config": {
@@ -495,8 +495,8 @@
       "integrity": "sha1-WqLipe1qvS5dHUc9NZb1dARP6ec=",
       "dev": true,
       "requires": {
-        "application-config-path": "^0.1.0",
-        "mkdirp": "^0.5.1"
+        "application-config-path": "0.1.0",
+        "mkdirp": "0.5.1"
       }
     },
     "application-config-path": {
@@ -517,7 +517,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -526,7 +526,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-filter": {
@@ -535,7 +535,7 @@
       "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
       "dev": true,
       "requires": {
-        "make-iterator": "^1.0.0"
+        "make-iterator": "1.0.1"
       }
     },
     "arr-flatten": {
@@ -550,7 +550,7 @@
       "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
       "dev": true,
       "requires": {
-        "make-iterator": "^1.0.0"
+        "make-iterator": "1.0.1"
       }
     },
     "arr-union": {
@@ -583,8 +583,8 @@
       "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
       "dev": true,
       "requires": {
-        "array-slice": "^1.0.0",
-        "is-number": "^4.0.0"
+        "array-slice": "1.1.0",
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -601,7 +601,7 @@
       "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0"
+        "is-number": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -624,9 +624,9 @@
       "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
       "dev": true,
       "requires": {
-        "default-compare": "^1.0.0",
-        "get-value": "^2.0.6",
-        "kind-of": "^5.0.2"
+        "default-compare": "1.0.0",
+        "get-value": "2.0.6",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -643,7 +643,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -676,7 +676,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "assert-plus": {
@@ -699,7 +699,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
@@ -709,10 +709,10 @@
       "integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.2",
-        "process-nextick-args": "^1.0.7",
-        "stream-exhaust": "^1.0.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0",
+        "process-nextick-args": "1.0.7",
+        "stream-exhaust": "1.0.2"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -747,7 +747,7 @@
       "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
       "dev": true,
       "requires": {
-        "async-done": "^1.2.2"
+        "async-done": "1.3.1"
       }
     },
     "asynckit": {
@@ -768,12 +768,12 @@
       "integrity": "sha512-qS5wW6aXHkm53Y4z73tFGsUhmZu4aMPV9iHXYlF0c/wxjknXNHuj/1cIQb+6YH692DbJGGWcckAXX+VxKvahMA==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.4.1",
-        "caniuse-lite": "^1.0.30000932",
-        "normalize-range": "^0.1.2",
-        "num2fraction": "^1.2.2",
-        "postcss": "^7.0.14",
-        "postcss-value-parser": "^3.3.1"
+        "browserslist": "4.4.1",
+        "caniuse-lite": "1.0.30000933",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "browserslist": {
@@ -782,9 +782,9 @@
           "integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000929",
-            "electron-to-chromium": "^1.3.103",
-            "node-releases": "^1.1.3"
+            "caniuse-lite": "1.0.30000933",
+            "electron-to-chromium": "1.3.110",
+            "node-releases": "1.1.6"
           }
         },
         "caniuse-lite": {
@@ -799,9 +799,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -810,7 +810,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -827,9 +827,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "postcss-value-parser": {
@@ -844,7 +844,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -867,8 +867,8 @@
       "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.2.5",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.8",
+        "is-buffer": "1.1.6"
       }
     },
     "babel-code-frame": {
@@ -877,9 +877,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -890,15 +890,15 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
@@ -915,25 +915,25 @@
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.1",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.6.0",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.11",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -950,14 +950,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.11",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "source-map": {
@@ -974,9 +974,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-call-delegate": {
@@ -985,10 +985,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-define-map": {
@@ -997,10 +997,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.11"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -1009,9 +1009,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -1020,11 +1020,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-get-function-arity": {
@@ -1033,8 +1033,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -1043,8 +1043,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -1053,8 +1053,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-regex": {
@@ -1063,9 +1063,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.11"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -1074,11 +1074,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-replace-supers": {
@@ -1087,12 +1087,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
@@ -1101,8 +1101,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-messages": {
@@ -1111,7 +1111,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -1120,7 +1120,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-external-helpers": {
@@ -1129,18 +1129,18 @@
       "integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
@@ -1156,9 +1156,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1167,7 +1167,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1176,7 +1176,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -1185,11 +1185,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.11"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1198,15 +1198,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-define-map": "6.26.0",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -1215,8 +1215,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -1225,7 +1225,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -1234,8 +1234,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -1244,7 +1244,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -1253,9 +1253,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -1264,7 +1264,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -1273,9 +1273,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1284,10 +1284,10 @@
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1296,9 +1296,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -1307,9 +1307,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1318,8 +1318,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1328,12 +1328,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1342,8 +1342,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1352,7 +1352,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1361,9 +1361,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1372,7 +1372,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1381,7 +1381,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1390,9 +1390,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1401,9 +1401,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1412,7 +1412,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.10.0"
+        "regenerator-transform": "0.10.1"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1421,8 +1421,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-preset-env": {
@@ -1431,36 +1431,36 @@
       "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-        "babel-plugin-transform-async-to-generator": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-        "babel-plugin-transform-es2015-classes": "^6.23.0",
-        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-        "babel-plugin-transform-es2015-for-of": "^6.23.0",
-        "babel-plugin-transform-es2015-function-name": "^6.22.0",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-        "babel-plugin-transform-es2015-object-super": "^6.22.0",
-        "babel-plugin-transform-es2015-parameters": "^6.23.0",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-        "babel-plugin-transform-regenerator": "^6.22.0",
-        "browserslist": "^3.2.6",
-        "invariant": "^2.2.2",
-        "semver": "^5.3.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "3.2.8",
+        "invariant": "2.2.4",
+        "semver": "5.5.1"
       },
       "dependencies": {
         "browserslist": {
@@ -1469,8 +1469,8 @@
           "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000844",
-            "electron-to-chromium": "^1.3.47"
+            "caniuse-lite": "1.0.30000888",
+            "electron-to-chromium": "1.3.73"
           }
         }
       }
@@ -1481,13 +1481,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
+        "babel-core": "6.26.3",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.11",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       }
     },
     "babel-runtime": {
@@ -1496,8 +1496,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
       }
     },
     "babel-template": {
@@ -1506,11 +1506,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.11"
       }
     },
     "babel-traverse": {
@@ -1519,15 +1519,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.4",
+        "lodash": "4.17.11"
       }
     },
     "babel-types": {
@@ -1536,10 +1536,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.11",
+        "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
@@ -1554,15 +1554,15 @@
       "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
       "dev": true,
       "requires": {
-        "arr-filter": "^1.1.1",
-        "arr-flatten": "^1.0.1",
-        "arr-map": "^2.0.0",
-        "array-each": "^1.0.0",
-        "array-initial": "^1.0.0",
-        "array-last": "^1.1.1",
-        "async-done": "^1.2.2",
-        "async-settle": "^1.0.0",
-        "now-and-later": "^2.0.0"
+        "arr-filter": "1.1.2",
+        "arr-flatten": "1.1.0",
+        "arr-map": "2.0.2",
+        "array-each": "1.0.1",
+        "array-initial": "1.1.0",
+        "array-last": "1.3.0",
+        "async-done": "1.3.1",
+        "async-settle": "1.0.0",
+        "now-and-later": "2.0.0"
       }
     },
     "backo2": {
@@ -1589,13 +1589,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1604,7 +1604,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -1613,7 +1613,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1622,7 +1622,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1631,9 +1631,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -1675,7 +1675,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "beeper": {
@@ -1705,7 +1705,7 @@
       "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
       "dev": true,
       "requires": {
-        "readable-stream": "~2.0.5"
+        "readable-stream": "2.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -1722,16 +1722,16 @@
         },
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
           }
         },
         "string_decoder": {
@@ -1760,13 +1760,13 @@
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^2.0.0"
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.4.1",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1793,8 +1793,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -1803,7 +1803,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -1814,7 +1814,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1824,9 +1824,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.3"
       }
     },
     "browser-sync": {
@@ -1835,16 +1835,16 @@
       "integrity": "sha512-NqXek0cPNEayQm77VGnD+qrwcVBTKMIQ9bdP6IWDRUTU1Bk7tZeq5QR3OG5Rr36Rao1t+Vx1QnfolHvvr5qsTA==",
       "dev": true,
       "requires": {
-        "browser-sync-ui": "v1.0.1",
+        "browser-sync-ui": "1.0.1",
         "bs-recipes": "1.3.4",
         "chokidar": "1.7.0",
         "connect": "3.6.6",
-        "connect-history-api-fallback": "^1.5.0",
-        "dev-ip": "^1.0.1",
-        "easy-extender": "^2.3.4",
+        "connect-history-api-fallback": "1.5.0",
+        "dev-ip": "1.0.1",
+        "easy-extender": "2.3.4",
         "eazy-logger": "3.0.2",
-        "etag": "^1.8.1",
-        "fresh": "^0.5.2",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
         "fs-extra": "3.0.1",
         "http-proxy": "1.15.2",
         "immutable": "3.8.2",
@@ -1853,7 +1853,7 @@
         "opn": "5.3.0",
         "portscanner": "2.1.1",
         "qs": "6.2.3",
-        "raw-body": "^2.3.2",
+        "raw-body": "2.3.3",
         "resp-modifier": "6.0.2",
         "rx": "4.1.0",
         "serve-index": "1.9.1",
@@ -1870,9 +1870,9 @@
           "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^3.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.1.11",
+            "jsonfile": "3.0.1",
+            "universalify": "0.1.2"
           }
         }
       }
@@ -1884,11 +1884,11 @@
       "dev": true,
       "requires": {
         "async-each-series": "0.1.1",
-        "connect-history-api-fallback": "^1.1.0",
-        "immutable": "^3.7.6",
+        "connect-history-api-fallback": "1.5.0",
+        "immutable": "3.8.2",
         "server-destroy": "1.0.1",
         "socket.io-client": "2.0.4",
-        "stream-throttle": "^0.1.3"
+        "stream-throttle": "0.1.3"
       }
     },
     "browserslist": {
@@ -1897,8 +1897,8 @@
       "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000792",
-        "electron-to-chromium": "^1.3.30"
+        "caniuse-lite": "1.0.30000888",
+        "electron-to-chromium": "1.3.73"
       }
     },
     "bs-recipes": {
@@ -1937,15 +1937,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       },
       "dependencies": {
         "isobject": {
@@ -1968,7 +1968,7 @@
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "requires": {
-        "callsites": "^2.0.0"
+        "callsites": "2.0.0"
       }
     },
     "caller-path": {
@@ -1977,7 +1977,7 @@
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "requires": {
-        "caller-callsite": "^2.0.0"
+        "caller-callsite": "2.0.0"
       }
     },
     "callsite": {
@@ -2004,8 +2004,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       },
       "dependencies": {
         "camelcase": {
@@ -2022,10 +2022,10 @@
       "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
-        "caniuse-lite": "^1.0.0",
-        "lodash.memoize": "^4.1.2",
-        "lodash.uniq": "^4.5.0"
+        "browserslist": "4.4.1",
+        "caniuse-lite": "1.0.30000888",
+        "lodash.memoize": "4.1.2",
+        "lodash.uniq": "4.5.0"
       },
       "dependencies": {
         "browserslist": {
@@ -2034,9 +2034,9 @@
           "integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000929",
-            "electron-to-chromium": "^1.3.103",
-            "node-releases": "^1.1.3"
+            "caniuse-lite": "1.0.30000933",
+            "electron-to-chromium": "1.3.110",
+            "node-releases": "1.1.6"
           },
           "dependencies": {
             "caniuse-lite": {
@@ -2091,9 +2091,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.5.0"
       }
     },
     "changelog-parser": {
@@ -2102,8 +2102,8 @@
       "integrity": "sha1-XWeqJGPPUI7xQV8AZmlZXH/h3qM=",
       "dev": true,
       "requires": {
-        "line-reader": "^0.2.4",
-        "remove-markdown": "^0.2.2"
+        "line-reader": "0.2.4",
+        "remove-markdown": "0.2.2"
       }
     },
     "character-entities": {
@@ -2142,15 +2142,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.2.4",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.2.1"
       }
     },
     "ci-info": {
@@ -2171,7 +2171,7 @@
       "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3"
+        "chalk": "1.1.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2186,11 +2186,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
@@ -2207,10 +2207,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -2219,7 +2219,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "isobject": {
@@ -2242,7 +2242,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-width": {
@@ -2257,9 +2257,9 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
       }
     },
     "clone": {
@@ -2280,8 +2280,8 @@
       "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
       "dev": true,
       "requires": {
-        "is-regexp": "^1.0.0",
-        "is-supported-regexp-flag": "^1.0.0"
+        "is-regexp": "1.0.0",
+        "is-supported-regexp-flag": "1.0.1"
       }
     },
     "clone-stats": {
@@ -2296,9 +2296,9 @@
       "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
+        "inherits": "2.0.3",
+        "process-nextick-args": "2.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "co": {
@@ -2313,9 +2313,9 @@
       "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
       "dev": true,
       "requires": {
-        "@types/q": "^1.5.1",
-        "chalk": "^2.4.1",
-        "q": "^1.1.2"
+        "@types/q": "1.5.1",
+        "chalk": "2.4.1",
+        "q": "1.5.1"
       }
     },
     "code-point-at": {
@@ -2336,9 +2336,9 @@
       "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
       "dev": true,
       "requires": {
-        "arr-map": "^2.0.2",
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "arr-map": "2.0.2",
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -2347,7 +2347,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -2358,8 +2358,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color": {
@@ -2368,9 +2368,9 @@
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.2",
-        "color-convert": "^1.3.0",
-        "color-string": "^0.3.0"
+        "clone": "1.0.4",
+        "color-convert": "1.9.3",
+        "color-string": "0.3.0"
       }
     },
     "color-convert": {
@@ -2394,7 +2394,7 @@
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "dev": true,
       "requires": {
-        "color-name": "^1.0.0"
+        "color-name": "1.1.3"
       }
     },
     "color-support": {
@@ -2409,9 +2409,9 @@
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
       "dev": true,
       "requires": {
-        "color": "^0.11.0",
+        "color": "0.11.4",
         "css-color-names": "0.0.4",
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
     },
     "colors": {
@@ -2426,7 +2426,7 @@
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -2465,10 +2465,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "configstore": {
@@ -2477,12 +2477,12 @@
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.3.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "connect": {
@@ -2493,7 +2493,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "~1.3.2",
+        "parseurl": "1.3.2",
         "utils-merge": "1.0.1"
       }
     },
@@ -2509,7 +2509,7 @@
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "cookie": {
@@ -2530,8 +2530,8 @@
       "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
       "dev": true,
       "requires": {
-        "each-props": "^1.3.0",
-        "is-plain-object": "^2.0.1"
+        "each-props": "1.3.2",
+        "is-plain-object": "2.0.4"
       }
     },
     "core-js": {
@@ -2552,10 +2552,10 @@
       "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
       "dev": true,
       "requires": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "parse-json": "^4.0.0"
+        "import-fresh": "2.0.0",
+        "is-directory": "0.3.1",
+        "js-yaml": "3.12.1",
+        "parse-json": "4.0.0"
       },
       "dependencies": {
         "parse-json": {
@@ -2564,8 +2564,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.2",
+            "json-parse-better-errors": "1.0.2"
           }
         }
       }
@@ -2576,7 +2576,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "1.0.1"
       }
     },
     "cross-spawn": {
@@ -2585,9 +2585,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.3",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "crypto-random-string": {
@@ -2602,10 +2602,10 @@
       "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.5.2",
-        "urix": "^0.1.0"
+        "inherits": "2.0.3",
+        "source-map": "0.6.1",
+        "source-map-resolve": "0.5.2",
+        "urix": "0.1.0"
       }
     },
     "css-color-function": {
@@ -2615,9 +2615,9 @@
       "dev": true,
       "requires": {
         "balanced-match": "0.1.0",
-        "color": "^0.11.0",
-        "debug": "^3.1.0",
-        "rgb": "~0.1.0"
+        "color": "0.11.4",
+        "debug": "3.2.5",
+        "rgb": "0.1.0"
       },
       "dependencies": {
         "balanced-match": {
@@ -2632,7 +2632,7 @@
           "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "ms": {
@@ -2655,8 +2655,8 @@
       "integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.1",
-        "timsort": "^0.3.0"
+        "postcss": "7.0.14",
+        "timsort": "0.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -2665,9 +2665,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -2676,7 +2676,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -2687,9 +2687,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -2698,7 +2698,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2715,10 +2715,10 @@
       "integrity": "sha512-MGhoq1S9EyPgZIGnts8Yz5WwUOyHmPMdlqeifsYs/xFX7AAm3hY0RJe1dqVlXtYPI66Nsk39R/sa5/ree6L2qg==",
       "dev": true,
       "requires": {
-        "boolbase": "^1.0.0",
-        "css-what": "2.1",
-        "domutils": "^1.7.0",
-        "nth-check": "^1.0.1"
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
+        "domutils": "1.7.0",
+        "nth-check": "1.0.1"
       }
     },
     "css-select-base-adapter": {
@@ -2733,8 +2733,8 @@
       "integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
       "dev": true,
       "requires": {
-        "mdn-data": "~1.1.0",
-        "source-map": "^0.5.3"
+        "mdn-data": "1.1.4",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -2775,10 +2775,10 @@
       "integrity": "sha512-5GIY0VzAHORpbKiL3rMXp4w4M1Ki+XlXgEXyuWXVd3h6hlASb+9Vo76dNP56/elLMVBBsUfusCo1q56uW0UWig==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^5.0.0",
-        "cssnano-preset-default": "^4.0.6",
-        "is-resolvable": "^1.0.0",
-        "postcss": "^7.0.0"
+        "cosmiconfig": "5.0.7",
+        "cssnano-preset-default": "4.0.6",
+        "is-resolvable": "1.1.0",
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -2787,9 +2787,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -2798,7 +2798,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -2809,9 +2809,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -2820,7 +2820,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2831,36 +2831,36 @@
       "integrity": "sha512-UPboYbFaJFtDUhJ4fqctThWbbyF4q01/7UhsZbLzp35l+nUxtzh1SifoVlEfyLM3n3Z0htd8B1YlCxy9i+bQvg==",
       "dev": true,
       "requires": {
-        "css-declaration-sorter": "^4.0.1",
-        "cssnano-util-raw-cache": "^4.0.1",
-        "postcss": "^7.0.0",
-        "postcss-calc": "^7.0.0",
-        "postcss-colormin": "^4.0.2",
-        "postcss-convert-values": "^4.0.1",
-        "postcss-discard-comments": "^4.0.1",
-        "postcss-discard-duplicates": "^4.0.2",
-        "postcss-discard-empty": "^4.0.1",
-        "postcss-discard-overridden": "^4.0.1",
-        "postcss-merge-longhand": "^4.0.10",
-        "postcss-merge-rules": "^4.0.2",
-        "postcss-minify-font-values": "^4.0.2",
-        "postcss-minify-gradients": "^4.0.1",
-        "postcss-minify-params": "^4.0.1",
-        "postcss-minify-selectors": "^4.0.1",
-        "postcss-normalize-charset": "^4.0.1",
-        "postcss-normalize-display-values": "^4.0.1",
-        "postcss-normalize-positions": "^4.0.1",
-        "postcss-normalize-repeat-style": "^4.0.1",
-        "postcss-normalize-string": "^4.0.1",
-        "postcss-normalize-timing-functions": "^4.0.1",
-        "postcss-normalize-unicode": "^4.0.1",
-        "postcss-normalize-url": "^4.0.1",
-        "postcss-normalize-whitespace": "^4.0.1",
-        "postcss-ordered-values": "^4.1.1",
-        "postcss-reduce-initial": "^4.0.2",
-        "postcss-reduce-transforms": "^4.0.1",
-        "postcss-svgo": "^4.0.1",
-        "postcss-unique-selectors": "^4.0.1"
+        "css-declaration-sorter": "4.0.1",
+        "cssnano-util-raw-cache": "4.0.1",
+        "postcss": "7.0.14",
+        "postcss-calc": "7.0.1",
+        "postcss-colormin": "4.0.2",
+        "postcss-convert-values": "4.0.1",
+        "postcss-discard-comments": "4.0.1",
+        "postcss-discard-duplicates": "4.0.2",
+        "postcss-discard-empty": "4.0.1",
+        "postcss-discard-overridden": "4.0.1",
+        "postcss-merge-longhand": "4.0.10",
+        "postcss-merge-rules": "4.0.2",
+        "postcss-minify-font-values": "4.0.2",
+        "postcss-minify-gradients": "4.0.1",
+        "postcss-minify-params": "4.0.1",
+        "postcss-minify-selectors": "4.0.1",
+        "postcss-normalize-charset": "4.0.1",
+        "postcss-normalize-display-values": "4.0.1",
+        "postcss-normalize-positions": "4.0.1",
+        "postcss-normalize-repeat-style": "4.0.1",
+        "postcss-normalize-string": "4.0.1",
+        "postcss-normalize-timing-functions": "4.0.1",
+        "postcss-normalize-unicode": "4.0.1",
+        "postcss-normalize-url": "4.0.1",
+        "postcss-normalize-whitespace": "4.0.1",
+        "postcss-ordered-values": "4.1.1",
+        "postcss-reduce-initial": "4.0.2",
+        "postcss-reduce-transforms": "4.0.1",
+        "postcss-svgo": "4.0.1",
+        "postcss-unique-selectors": "4.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -2869,9 +2869,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -2880,7 +2880,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -2891,9 +2891,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -2902,7 +2902,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2925,7 +2925,7 @@
       "integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -2934,9 +2934,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -2945,7 +2945,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -2956,9 +2956,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -2967,7 +2967,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2993,8 +2993,8 @@
           "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
           "dev": true,
           "requires": {
-            "mdn-data": "~1.1.0",
-            "source-map": "^0.5.3"
+            "mdn-data": "1.1.4",
+            "source-map": "0.5.7"
           }
         },
         "source-map": {
@@ -3011,7 +3011,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "d": {
@@ -3020,7 +3020,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.46"
       }
     },
     "dashdash": {
@@ -3029,7 +3029,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "dateformat": {
@@ -3053,9 +3053,9 @@
       "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
       "dev": true,
       "requires": {
-        "debug": "3.X",
-        "memoizee": "0.4.X",
-        "object-assign": "4.X"
+        "debug": "3.2.5",
+        "memoizee": "0.4.14",
+        "object-assign": "4.1.1"
       },
       "dependencies": {
         "debug": {
@@ -3064,7 +3064,7 @@
           "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "ms": {
@@ -3087,8 +3087,8 @@
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
+        "decamelize": "1.2.0",
+        "map-obj": "1.0.1"
       }
     },
     "decode-uri-component": {
@@ -3115,7 +3115,7 @@
       "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^5.0.2"
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3138,7 +3138,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "object-keys": "1.0.12"
       },
       "dependencies": {
         "object-keys": {
@@ -3155,8 +3155,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -3165,7 +3165,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -3174,7 +3174,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -3183,9 +3183,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -3238,7 +3238,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "detect-newline": {
@@ -3259,7 +3259,7 @@
       "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
       "dev": true,
       "requires": {
-        "path-type": "^3.0.0"
+        "path-type": "3.0.0"
       },
       "dependencies": {
         "path-type": {
@@ -3268,7 +3268,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -3285,7 +3285,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.2"
       }
     },
     "dom-serializer": {
@@ -3294,8 +3294,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -3318,7 +3318,7 @@
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
       "dev": true,
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "1.3.0"
       }
     },
     "domutils": {
@@ -3327,8 +3327,8 @@
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
       "dev": true,
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
       }
     },
     "dot-prop": {
@@ -3337,7 +3337,7 @@
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "duplexer": {
@@ -3352,7 +3352,7 @@
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.1.9"
+        "readable-stream": "1.1.14"
       },
       "dependencies": {
         "isarray": {
@@ -3363,14 +3363,14 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -3393,10 +3393,10 @@
       "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
       }
     },
     "each-props": {
@@ -3405,8 +3405,8 @@
       "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
       "dev": true,
       "requires": {
-        "is-plain-object": "^2.0.1",
-        "object.defaults": "^1.1.0"
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0"
       }
     },
     "easy-extender": {
@@ -3415,7 +3415,7 @@
       "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.11"
       }
     },
     "eazy-logger": {
@@ -3424,7 +3424,7 @@
       "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
       "dev": true,
       "requires": {
-        "tfunk": "^3.0.1"
+        "tfunk": "3.1.0"
       }
     },
     "ecc-jsbn": {
@@ -3434,8 +3434,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "ee-first": {
@@ -3474,7 +3474,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "engine.io": {
@@ -3483,12 +3483,12 @@
       "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "ws": "~3.3.1"
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
+        "ws": "3.3.3"
       },
       "dependencies": {
         "debug": {
@@ -3510,14 +3510,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "~3.3.1",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "ws": "3.3.3",
+        "xmlhttprequest-ssl": "1.5.5",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -3539,10 +3539,10 @@
       "dev": true,
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
+        "arraybuffer.slice": "0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "~1.0.2"
+        "has-binary2": "1.0.3"
       }
     },
     "entities": {
@@ -3557,7 +3557,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -3566,11 +3566,11 @@
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.2.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.4",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -3579,9 +3579,9 @@
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "1.1.4",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.2"
       }
     },
     "es5-ext": {
@@ -3590,9 +3590,9 @@
       "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -3601,9 +3601,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-symbol": {
@@ -3612,8 +3612,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46"
       }
     },
     "es6-weak-map": {
@@ -3622,10 +3622,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "escape-html": {
@@ -3646,43 +3646,43 @@
       "integrity": "sha512-54NV+JkTpTu0d8+UYSA8mMKAG4XAsaOrozA9rCW7tgneg1mevcL7wIotPC+fZ0SkWwdhNqoXoxnQCTBp7UvTsg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.5.3",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
-        "debug": "^4.0.1",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^4.0.0",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^5.0.0",
-        "esquery": "^1.0.1",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.7.0",
-        "ignore": "^4.0.6",
-        "import-fresh": "^3.0.0",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^6.1.0",
-        "js-yaml": "^3.12.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.5",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
-        "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "semver": "^5.5.1",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
-        "table": "^5.0.2",
-        "text-table": "^0.2.0"
+        "@babel/code-frame": "7.0.0",
+        "ajv": "6.7.0",
+        "chalk": "2.4.1",
+        "cross-spawn": "6.0.5",
+        "debug": "4.1.1",
+        "doctrine": "2.1.0",
+        "eslint-scope": "4.0.0",
+        "eslint-utils": "1.3.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "5.0.0",
+        "esquery": "1.0.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.3",
+        "globals": "11.10.0",
+        "ignore": "4.0.6",
+        "import-fresh": "3.0.0",
+        "imurmurhash": "0.1.4",
+        "inquirer": "6.2.2",
+        "js-yaml": "3.12.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.11",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.3",
+        "regexpp": "2.0.1",
+        "semver": "5.5.1",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "5.2.2",
+        "text-table": "0.2.0"
       },
       "dependencies": {
         "ajv": {
@@ -3691,10 +3691,10 @@
           "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
           }
         },
         "ansi-regex": {
@@ -3709,11 +3709,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "nice-try": "1.0.5",
+            "path-key": "2.0.1",
+            "semver": "5.5.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
           }
         },
         "debug": {
@@ -3722,7 +3722,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "fast-deep-equal": {
@@ -3743,8 +3743,8 @@
           "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
           "dev": true,
           "requires": {
-            "parent-module": "^1.0.0",
-            "resolve-from": "^4.0.0"
+            "parent-module": "1.0.0",
+            "resolve-from": "4.0.0"
           }
         },
         "json-schema-traverse": {
@@ -3771,7 +3771,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -3788,8 +3788,8 @@
       "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       }
     },
     "eslint-utils": {
@@ -3810,9 +3810,9 @@
       "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
       "dev": true,
       "requires": {
-        "acorn": "^6.0.2",
-        "acorn-jsx": "^5.0.0",
-        "eslint-visitor-keys": "^1.0.0"
+        "acorn": "6.0.6",
+        "acorn-jsx": "5.0.1",
+        "eslint-visitor-keys": "1.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -3835,7 +3835,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.2.0"
       }
     },
     "esrecurse": {
@@ -3844,7 +3844,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -3877,8 +3877,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46"
       }
     },
     "eventemitter3": {
@@ -3893,13 +3893,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "execall": {
@@ -3908,7 +3908,7 @@
       "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
       "dev": true,
       "requires": {
-        "clone-regexp": "^1.0.0"
+        "clone-regexp": "1.0.1"
       }
     },
     "expand-brackets": {
@@ -3917,7 +3917,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -3926,7 +3926,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.4"
       }
     },
     "expand-tilde": {
@@ -3935,7 +3935,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "extend": {
@@ -3950,8 +3950,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -3960,7 +3960,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -3971,9 +3971,9 @@
       "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
+        "chardet": "0.7.0",
+        "iconv-lite": "0.4.24",
+        "tmp": "0.0.33"
       },
       "dependencies": {
         "iconv-lite": {
@@ -3982,7 +3982,7 @@
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         }
       }
@@ -3993,7 +3993,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "extsprintf": {
@@ -4008,9 +4008,9 @@
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "ansi-gray": "^0.1.1",
-        "color-support": "^1.1.3",
-        "time-stamp": "^1.0.0"
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "time-stamp": "1.1.0"
       }
     },
     "fast-deep-equal": {
@@ -4025,12 +4025,12 @@
       "integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
       "dev": true,
       "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.3",
-        "micromatch": "^3.1.10"
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "@nodelib/fs.stat": "1.1.3",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.0",
+        "merge2": "1.2.3",
+        "micromatch": "3.1.10"
       },
       "dependencies": {
         "arr-diff": {
@@ -4051,16 +4051,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4069,7 +4069,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4080,13 +4080,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -4095,7 +4095,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -4104,7 +4104,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -4113,7 +4113,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -4122,7 +4122,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -4133,7 +4133,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -4142,7 +4142,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -4153,9 +4153,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -4172,14 +4172,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -4188,7 +4188,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -4197,7 +4197,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4208,10 +4208,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4220,7 +4220,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4231,8 +4231,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -4241,7 +4241,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -4252,7 +4252,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -4261,7 +4261,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -4270,9 +4270,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -4287,7 +4287,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -4296,7 +4296,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4305,7 +4305,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4328,19 +4328,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -4363,7 +4363,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -4372,8 +4372,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.4",
+        "object-assign": "4.1.1"
       }
     },
     "filename-regex": {
@@ -4394,9 +4394,9 @@
       "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
       "dev": true,
       "requires": {
-        "filename-reserved-regex": "^1.0.0",
-        "strip-outer": "^1.0.0",
-        "trim-repeated": "^1.0.0"
+        "filename-reserved-regex": "1.0.0",
+        "strip-outer": "1.0.1",
+        "trim-repeated": "1.0.0"
       }
     },
     "filenamify-url": {
@@ -4405,8 +4405,8 @@
       "integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
       "dev": true,
       "requires": {
-        "filenamify": "^1.0.0",
-        "humanize-url": "^1.0.0"
+        "filenamify": "1.2.1",
+        "humanize-url": "1.0.1"
       }
     },
     "fill-range": {
@@ -4415,11 +4415,11 @@
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^3.0.0",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "3.1.0",
+        "repeat-element": "1.1.3",
+        "repeat-string": "1.6.1"
       }
     },
     "finalhandler": {
@@ -4429,12 +4429,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.1",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.3.1",
-        "unpipe": "~1.0.0"
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
       }
     },
     "find-up": {
@@ -4443,8 +4443,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "findup-sync": {
@@ -4453,10 +4453,10 @@
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "3.1.0",
+        "micromatch": "3.1.10",
+        "resolve-dir": "1.0.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -4477,16 +4477,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4495,7 +4495,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4506,13 +4506,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -4521,7 +4521,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -4530,7 +4530,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -4539,7 +4539,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -4548,7 +4548,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -4559,7 +4559,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -4568,7 +4568,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -4579,9 +4579,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -4598,14 +4598,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -4614,7 +4614,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -4623,7 +4623,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4634,10 +4634,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -4646,7 +4646,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -4657,7 +4657,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -4666,7 +4666,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -4675,9 +4675,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -4692,7 +4692,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -4701,7 +4701,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4710,7 +4710,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4733,19 +4733,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -4756,11 +4756,11 @@
       "integrity": "sha512-jQp949ZmEbiYHk3gkbdtpJ0G1+kgtLQBNdP5edFP7Fh+WAYceLQz6yO1SBj72Xkg8GVyTB3bBzAYrHJVh5Xd5g==",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "is-plain-object": "^2.0.3",
-        "object.defaults": "^1.1.0",
-        "object.pick": "^1.2.0",
-        "parse-filepath": "^1.0.1"
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
       }
     },
     "first-chunk-stream": {
@@ -4769,7 +4769,7 @@
       "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.6"
       }
     },
     "flagged-respawn": {
@@ -4784,10 +4784,10 @@
       "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "graceful-fs": "^4.1.2",
-        "rimraf": "~2.6.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "graceful-fs": "4.1.11",
+        "rimraf": "2.6.3",
+        "write": "0.2.1"
       }
     },
     "flatted": {
@@ -4808,8 +4808,8 @@
       "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.4"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "follow-redirects": {
@@ -4818,7 +4818,7 @@
       "integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
       "dev": true,
       "requires": {
-        "debug": "=3.1.0"
+        "debug": "3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -4844,7 +4844,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "forever-agent": {
@@ -4859,9 +4859,9 @@
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.20"
       },
       "dependencies": {
         "combined-stream": {
@@ -4870,7 +4870,7 @@
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "dev": true,
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         }
       }
@@ -4881,7 +4881,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fresh": {
@@ -4896,9 +4896,9 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.2"
       },
       "dependencies": {
         "jsonfile": {
@@ -4907,7 +4907,7 @@
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.1.11"
           }
         }
       }
@@ -4918,8 +4918,8 @@
       "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "through2": "^2.0.3"
+        "graceful-fs": "4.1.11",
+        "through2": "2.0.3"
       }
     },
     "fs.realpath": {
@@ -4935,8 +4935,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.11.1",
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -4966,8 +4966,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -4982,7 +4982,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -5056,7 +5056,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
@@ -5073,14 +5073,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "glob": {
@@ -5090,12 +5090,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -5112,7 +5112,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -5122,7 +5122,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -5132,8 +5132,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -5155,7 +5155,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -5171,7 +5171,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -5186,8 +5186,8 @@
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
@@ -5197,7 +5197,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "mkdirp": {
@@ -5223,9 +5223,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -5235,16 +5235,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
@@ -5254,8 +5254,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -5272,8 +5272,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -5283,10 +5283,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -5308,7 +5308,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -5332,8 +5332,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -5357,10 +5357,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -5379,13 +5379,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -5395,7 +5395,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -5445,9 +5445,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -5457,7 +5457,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -5466,7 +5466,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -5483,13 +5483,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
@@ -5506,7 +5506,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -5565,7 +5565,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "gh-pages": {
@@ -5574,14 +5574,14 @@
       "integrity": "sha512-uFlk3bukljeiWKQ2XvPfjcSi/ou7IfoDf2p+Fj672saLAr8bnOdFVqI/JSgrSgInKpCg5BksxEwGUl++dbg8Dg==",
       "dev": true,
       "requires": {
-        "async": "^2.6.1",
-        "commander": "^2.18.0",
-        "email-addresses": "^3.0.1",
-        "filenamify-url": "^1.0.0",
-        "fs-extra": "^7.0.0",
-        "globby": "^6.1.0",
-        "graceful-fs": "^4.1.11",
-        "rimraf": "^2.6.2"
+        "async": "2.6.1",
+        "commander": "2.18.0",
+        "email-addresses": "3.0.3",
+        "filenamify-url": "1.0.0",
+        "fs-extra": "7.0.1",
+        "globby": "6.1.0",
+        "graceful-fs": "4.1.11",
+        "rimraf": "2.6.3"
       },
       "dependencies": {
         "async": {
@@ -5590,7 +5590,7 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "4.17.11"
           }
         }
       }
@@ -5601,17 +5601,17 @@
       "integrity": "sha512-j2r8PW1un/ILRTn++Ku94pElPDA2+fJoa6Anb0iorOV6Ch3hj/5ujEqMdUuc2g2BG/OvJc7LuycEu5Cj88ceiw==",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "changelog-parser": "^2.0.0",
-        "deep-extend": "^0.6.0",
-        "gh-release-assets": "^1.1.0",
-        "ghauth": "^3.2.0",
-        "github-url-to-object": "^3.0.0",
-        "inquirer": "^6.2.0",
-        "request": "^2.82.0",
-        "shelljs": "^0.3.0",
-        "update-notifier": "^2.2.0",
-        "yargs": "^2.1.1"
+        "chalk": "1.1.3",
+        "changelog-parser": "2.5.0",
+        "deep-extend": "0.6.0",
+        "gh-release-assets": "1.1.2",
+        "ghauth": "3.2.1",
+        "github-url-to-object": "3.1.0",
+        "inquirer": "6.2.0",
+        "request": "2.88.0",
+        "shelljs": "0.3.0",
+        "update-notifier": "2.5.0",
+        "yargs": "2.3.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5628,15 +5628,15 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "chardet": {
@@ -5651,9 +5651,9 @@
           "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
           "dev": true,
           "requires": {
-            "chardet": "^0.7.0",
-            "iconv-lite": "^0.4.24",
-            "tmp": "^0.0.33"
+            "chardet": "0.7.0",
+            "iconv-lite": "0.4.24",
+            "tmp": "0.0.33"
           }
         },
         "iconv-lite": {
@@ -5662,7 +5662,7 @@
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "inquirer": {
@@ -5671,19 +5671,19 @@
           "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.0",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.10",
+            "ansi-escapes": "3.1.0",
+            "chalk": "2.4.1",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "3.0.3",
+            "figures": "2.0.0",
+            "lodash": "4.17.11",
             "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.1.0",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
-            "through": "^2.3.6"
+            "run-async": "2.3.0",
+            "rxjs": "6.3.3",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
           },
           "dependencies": {
             "ansi-styles": {
@@ -5692,7 +5692,7 @@
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "dev": true,
               "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.3"
               }
             },
             "chalk": {
@@ -5701,9 +5701,9 @@
               "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.5.0"
               }
             },
             "strip-ansi": {
@@ -5712,7 +5712,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             },
             "supports-color": {
@@ -5721,7 +5721,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -5738,8 +5738,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
             "strip-ansi": {
@@ -5748,7 +5748,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -5767,7 +5767,7 @@
         },
         "yargs": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-2.3.0.tgz",
           "integrity": "sha1-6QDIclDsXNCA22AJ/j3WMVbx1/s=",
           "dev": true,
           "requires": {
@@ -5782,16 +5782,16 @@
       "integrity": "sha1-771OrzKUoZhWNr/2s7lkXY/9lFc=",
       "dev": true,
       "requires": {
-        "async": "^0.9.0",
-        "mime": "^1.3.4",
-        "progress-stream": "^2.0.0",
-        "request": "^2.85.0",
-        "util-extend": "^1.0.1"
+        "async": "0.9.2",
+        "mime": "1.4.1",
+        "progress-stream": "2.0.0",
+        "request": "2.88.0",
+        "util-extend": "1.0.3"
       },
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
           "dev": true
         }
@@ -5803,12 +5803,12 @@
       "integrity": "sha1-RddVZDcWSti0sDfALGJ/1VAZ4xo=",
       "dev": true,
       "requires": {
-        "application-config": "~1.0.0",
-        "bl": "~1.1.2",
-        "hyperquest": "~2.0.0",
-        "mkdirp": "~0.5.1",
-        "read": "~1.0.7",
-        "xtend": "~4.0.1"
+        "application-config": "1.0.1",
+        "bl": "1.1.2",
+        "hyperquest": "2.0.0",
+        "mkdirp": "0.5.1",
+        "read": "1.0.7",
+        "xtend": "4.0.1"
       }
     },
     "github-url-to-object": {
@@ -5817,7 +5817,7 @@
       "integrity": "sha1-FgpdVa188EWeB1f3kS1xgHa37X0=",
       "dev": true,
       "requires": {
-        "is-url": "^1.1.0"
+        "is-url": "1.2.4"
       }
     },
     "glob": {
@@ -5826,12 +5826,12 @@
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -5840,8 +5840,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -5850,7 +5850,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "glob-stream": {
@@ -5859,16 +5859,16 @@
       "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "glob": "^7.1.1",
-        "glob-parent": "^3.1.0",
-        "is-negated-glob": "^1.0.0",
-        "ordered-read-streams": "^1.0.0",
-        "pumpify": "^1.3.5",
-        "readable-stream": "^2.1.5",
-        "remove-trailing-separator": "^1.0.1",
-        "to-absolute-glob": "^2.0.0",
-        "unique-stream": "^2.0.2"
+        "extend": "3.0.2",
+        "glob": "7.1.3",
+        "glob-parent": "3.1.0",
+        "is-negated-glob": "1.0.0",
+        "ordered-read-streams": "1.0.1",
+        "pumpify": "1.5.1",
+        "readable-stream": "2.3.6",
+        "remove-trailing-separator": "1.1.0",
+        "to-absolute-glob": "2.0.2",
+        "unique-stream": "2.3.1"
       },
       "dependencies": {
         "glob-parent": {
@@ -5877,8 +5877,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           }
         },
         "is-extglob": {
@@ -5893,7 +5893,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.0"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -5910,12 +5910,12 @@
       "integrity": "sha512-8tWsULNEPHKQ2MR4zXuzSmqbdyV5PtwwCaWSGQ1WwHsJ07ilNeN1JB8ntxhckbnpSHaf9dXFUHzIWvm1I13dsg==",
       "dev": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-done": "^1.2.0",
-        "chokidar": "^2.0.0",
-        "is-negated-glob": "^1.0.0",
-        "just-debounce": "^1.0.0",
-        "object.defaults": "^1.1.0"
+        "anymatch": "2.0.0",
+        "async-done": "1.3.1",
+        "chokidar": "2.0.4",
+        "is-negated-glob": "1.0.0",
+        "just-debounce": "1.0.0",
+        "object.defaults": "1.1.0"
       },
       "dependencies": {
         "anymatch": {
@@ -5924,8 +5924,8 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "^3.1.4",
-            "normalize-path": "^2.1.1"
+            "micromatch": "3.1.10",
+            "normalize-path": "2.1.1"
           }
         },
         "arr-diff": {
@@ -5946,16 +5946,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -5964,7 +5964,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5975,19 +5975,19 @@
           "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
           "dev": true,
           "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.0",
-            "braces": "^2.3.0",
-            "fsevents": "^1.2.2",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.1",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "lodash.debounce": "^4.0.8",
-            "normalize-path": "^2.1.1",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.0.0",
-            "upath": "^1.0.5"
+            "anymatch": "2.0.0",
+            "async-each": "1.0.1",
+            "braces": "2.3.2",
+            "fsevents": "1.2.4",
+            "glob-parent": "3.1.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "4.0.0",
+            "lodash.debounce": "4.0.8",
+            "normalize-path": "2.1.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.2.1",
+            "upath": "1.1.0"
           }
         },
         "expand-brackets": {
@@ -5996,13 +5996,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -6011,7 +6011,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -6020,7 +6020,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -6029,7 +6029,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -6038,7 +6038,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -6049,7 +6049,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -6058,7 +6058,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -6069,9 +6069,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -6088,14 +6088,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -6104,7 +6104,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -6113,7 +6113,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -6124,10 +6124,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -6136,7 +6136,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -6147,8 +6147,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -6157,7 +6157,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -6168,7 +6168,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -6177,7 +6177,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -6186,9 +6186,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -6203,7 +6203,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -6212,7 +6212,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -6221,7 +6221,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -6244,19 +6244,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -6267,7 +6267,7 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "1.3.5"
       }
     },
     "global-modules": {
@@ -6276,9 +6276,9 @@
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
-        "global-prefix": "^1.0.1",
-        "is-windows": "^1.0.1",
-        "resolve-dir": "^1.0.0"
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
       }
     },
     "global-prefix": {
@@ -6287,11 +6287,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.1"
       }
     },
     "globals": {
@@ -6306,11 +6306,11 @@
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "glob": "7.1.3",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "globjoin": {
@@ -6325,7 +6325,7 @@
       "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.1"
       }
     },
     "gonzales-pe": {
@@ -6334,7 +6334,7 @@
       "integrity": "sha512-Kjhohco0esHQnOiqqdJeNz/5fyPkOMD/d6XVjwTAoPGUFh0mCollPUTUTa2OZy4dYNAqlPIQdTiNzJTWdd9Htw==",
       "dev": true,
       "requires": {
-        "minimist": "1.1.x"
+        "minimist": "1.1.3"
       },
       "dependencies": {
         "minimist": {
@@ -6347,21 +6347,21 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
-        "create-error-class": "^3.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.1",
+        "safe-buffer": "5.1.2",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
       }
     },
     "graceful-fs": {
@@ -6376,10 +6376,10 @@
       "integrity": "sha1-lXZsYB2t5Kd+0+eyttwDiBtZY2Y=",
       "dev": true,
       "requires": {
-        "glob-watcher": "^5.0.0",
-        "gulp-cli": "^2.0.0",
-        "undertaker": "^1.0.0",
-        "vinyl-fs": "^3.0.0"
+        "glob-watcher": "5.0.3",
+        "gulp-cli": "2.0.1",
+        "undertaker": "1.2.0",
+        "vinyl-fs": "3.0.3"
       },
       "dependencies": {
         "gulp-cli": {
@@ -6388,24 +6388,24 @@
           "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
           "dev": true,
           "requires": {
-            "ansi-colors": "^1.0.1",
-            "archy": "^1.0.0",
-            "array-sort": "^1.0.0",
-            "color-support": "^1.1.3",
-            "concat-stream": "^1.6.0",
-            "copy-props": "^2.0.1",
-            "fancy-log": "^1.3.2",
-            "gulplog": "^1.0.0",
-            "interpret": "^1.1.0",
-            "isobject": "^3.0.1",
-            "liftoff": "^2.5.0",
-            "matchdep": "^2.0.0",
-            "mute-stdout": "^1.0.0",
-            "pretty-hrtime": "^1.0.0",
-            "replace-homedir": "^1.0.0",
-            "semver-greatest-satisfied-range": "^1.1.0",
-            "v8flags": "^3.0.1",
-            "yargs": "^7.1.0"
+            "ansi-colors": "1.1.0",
+            "archy": "1.0.0",
+            "array-sort": "1.0.0",
+            "color-support": "1.1.3",
+            "concat-stream": "1.6.2",
+            "copy-props": "2.0.4",
+            "fancy-log": "1.3.2",
+            "gulplog": "1.0.0",
+            "interpret": "1.2.0",
+            "isobject": "3.0.1",
+            "liftoff": "2.5.0",
+            "matchdep": "2.0.0",
+            "mute-stdout": "1.0.1",
+            "pretty-hrtime": "1.0.3",
+            "replace-homedir": "1.0.0",
+            "semver-greatest-satisfied-range": "1.1.0",
+            "v8flags": "3.1.2",
+            "yargs": "7.1.0"
           }
         },
         "isobject": {
@@ -6420,19 +6420,19 @@
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^5.0.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
           }
         },
         "yargs-parser": {
@@ -6441,7 +6441,7 @@
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0"
+            "camelcase": "3.0.0"
           }
         }
       }
@@ -6452,9 +6452,9 @@
       "integrity": "sha1-AgijFJg/3IUclemUSwp88wVHn6M=",
       "dev": true,
       "requires": {
-        "gulp-util": "~3.0.7",
-        "through2": "~2.0.0",
-        "underscore.template": "~0.1.2"
+        "gulp-util": "3.0.8",
+        "through2": "2.0.3",
+        "underscore.template": "0.1.7"
       }
     },
     "gulp-cssnano": {
@@ -6463,11 +6463,11 @@
       "integrity": "sha512-r8qdX5pTXsBb/IRm9loE8Ijz8UiPW/URMC/bKJe4FPNHRaz4aEx8Bev03L0FYHd/7BSGu/ebmfumAkpGuTdenA==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "cssnano": "^3.0.0",
-        "object-assign": "^4.0.1",
-        "plugin-error": "^1.0.1",
-        "vinyl-sourcemaps-apply": "^0.2.1"
+        "buffer-from": "1.1.1",
+        "cssnano": "3.10.0",
+        "object-assign": "4.1.1",
+        "plugin-error": "1.0.1",
+        "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6482,12 +6482,12 @@
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "dev": true,
           "requires": {
-            "browserslist": "^1.7.6",
-            "caniuse-db": "^1.0.30000634",
-            "normalize-range": "^0.1.2",
-            "num2fraction": "^1.2.2",
-            "postcss": "^5.2.16",
-            "postcss-value-parser": "^3.2.3"
+            "browserslist": "1.7.7",
+            "caniuse-db": "1.0.30000933",
+            "normalize-range": "0.1.2",
+            "num2fraction": "1.2.2",
+            "postcss": "5.2.18",
+            "postcss-value-parser": "3.3.0"
           }
         },
         "browserslist": {
@@ -6496,8 +6496,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "^1.0.30000639",
-            "electron-to-chromium": "^1.2.7"
+            "caniuse-db": "1.0.30000933",
+            "electron-to-chromium": "1.3.73"
           }
         },
         "caniuse-api": {
@@ -6506,10 +6506,10 @@
           "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
           "dev": true,
           "requires": {
-            "browserslist": "^1.3.6",
-            "caniuse-db": "^1.0.30000529",
-            "lodash.memoize": "^4.1.2",
-            "lodash.uniq": "^4.5.0"
+            "browserslist": "1.7.7",
+            "caniuse-db": "1.0.30000933",
+            "lodash.memoize": "4.1.2",
+            "lodash.uniq": "4.5.0"
           }
         },
         "chalk": {
@@ -6518,11 +6518,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -6539,7 +6539,7 @@
           "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
           "dev": true,
           "requires": {
-            "q": "^1.1.2"
+            "q": "1.5.1"
           }
         },
         "cssnano": {
@@ -6548,38 +6548,38 @@
           "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
           "dev": true,
           "requires": {
-            "autoprefixer": "^6.3.1",
-            "decamelize": "^1.1.2",
-            "defined": "^1.0.0",
-            "has": "^1.0.1",
-            "object-assign": "^4.0.1",
-            "postcss": "^5.0.14",
-            "postcss-calc": "^5.2.0",
-            "postcss-colormin": "^2.1.8",
-            "postcss-convert-values": "^2.3.4",
-            "postcss-discard-comments": "^2.0.4",
-            "postcss-discard-duplicates": "^2.0.1",
-            "postcss-discard-empty": "^2.0.1",
-            "postcss-discard-overridden": "^0.1.1",
-            "postcss-discard-unused": "^2.2.1",
-            "postcss-filter-plugins": "^2.0.0",
-            "postcss-merge-idents": "^2.1.5",
-            "postcss-merge-longhand": "^2.0.1",
-            "postcss-merge-rules": "^2.0.3",
-            "postcss-minify-font-values": "^1.0.2",
-            "postcss-minify-gradients": "^1.0.1",
-            "postcss-minify-params": "^1.0.4",
-            "postcss-minify-selectors": "^2.0.4",
-            "postcss-normalize-charset": "^1.1.0",
-            "postcss-normalize-url": "^3.0.7",
-            "postcss-ordered-values": "^2.1.0",
-            "postcss-reduce-idents": "^2.2.2",
-            "postcss-reduce-initial": "^1.0.0",
-            "postcss-reduce-transforms": "^1.0.3",
-            "postcss-svgo": "^2.1.1",
-            "postcss-unique-selectors": "^2.0.2",
-            "postcss-value-parser": "^3.2.3",
-            "postcss-zindex": "^2.0.1"
+            "autoprefixer": "6.7.7",
+            "decamelize": "1.2.0",
+            "defined": "1.0.0",
+            "has": "1.0.3",
+            "object-assign": "4.1.1",
+            "postcss": "5.2.18",
+            "postcss-calc": "5.3.1",
+            "postcss-colormin": "2.2.2",
+            "postcss-convert-values": "2.6.1",
+            "postcss-discard-comments": "2.0.4",
+            "postcss-discard-duplicates": "2.1.0",
+            "postcss-discard-empty": "2.1.0",
+            "postcss-discard-overridden": "0.1.1",
+            "postcss-discard-unused": "2.2.3",
+            "postcss-filter-plugins": "2.0.3",
+            "postcss-merge-idents": "2.1.7",
+            "postcss-merge-longhand": "2.0.2",
+            "postcss-merge-rules": "2.1.2",
+            "postcss-minify-font-values": "1.0.5",
+            "postcss-minify-gradients": "1.0.5",
+            "postcss-minify-params": "1.2.2",
+            "postcss-minify-selectors": "2.1.1",
+            "postcss-normalize-charset": "1.1.1",
+            "postcss-normalize-url": "3.0.8",
+            "postcss-ordered-values": "2.2.3",
+            "postcss-reduce-idents": "2.4.0",
+            "postcss-reduce-initial": "1.0.1",
+            "postcss-reduce-transforms": "1.0.4",
+            "postcss-svgo": "2.1.6",
+            "postcss-unique-selectors": "2.0.2",
+            "postcss-value-parser": "3.3.0",
+            "postcss-zindex": "2.2.0"
           }
         },
         "csso": {
@@ -6588,8 +6588,8 @@
           "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
           "dev": true,
           "requires": {
-            "clap": "^1.0.9",
-            "source-map": "^0.5.3"
+            "clap": "1.2.3",
+            "source-map": "0.5.7"
           }
         },
         "esprima": {
@@ -6610,7 +6610,7 @@
           "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
           "dev": true,
           "requires": {
-            "html-comment-regex": "^1.1.0"
+            "html-comment-regex": "1.1.2"
           }
         },
         "js-yaml": {
@@ -6619,8 +6619,8 @@
           "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^2.6.0"
+            "argparse": "1.0.10",
+            "esprima": "2.7.3"
           }
         },
         "normalize-url": {
@@ -6629,10 +6629,10 @@
           "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
           "dev": true,
           "requires": {
-            "object-assign": "^4.0.1",
-            "prepend-http": "^1.0.0",
-            "query-string": "^4.1.0",
-            "sort-keys": "^1.0.0"
+            "object-assign": "4.1.1",
+            "prepend-http": "1.0.4",
+            "query-string": "4.3.4",
+            "sort-keys": "1.1.2"
           }
         },
         "postcss": {
@@ -6641,10 +6641,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.5.1",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "postcss-calc": {
@@ -6653,9 +6653,9 @@
           "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
           "dev": true,
           "requires": {
-            "postcss": "^5.0.2",
-            "postcss-message-helpers": "^2.0.0",
-            "reduce-css-calc": "^1.2.6"
+            "postcss": "5.2.18",
+            "postcss-message-helpers": "2.0.0",
+            "reduce-css-calc": "1.3.0"
           }
         },
         "postcss-colormin": {
@@ -6664,9 +6664,9 @@
           "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
           "dev": true,
           "requires": {
-            "colormin": "^1.0.5",
-            "postcss": "^5.0.13",
-            "postcss-value-parser": "^3.2.3"
+            "colormin": "1.1.2",
+            "postcss": "5.2.18",
+            "postcss-value-parser": "3.3.0"
           }
         },
         "postcss-convert-values": {
@@ -6675,8 +6675,8 @@
           "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
           "dev": true,
           "requires": {
-            "postcss": "^5.0.11",
-            "postcss-value-parser": "^3.1.2"
+            "postcss": "5.2.18",
+            "postcss-value-parser": "3.3.0"
           }
         },
         "postcss-discard-comments": {
@@ -6685,7 +6685,7 @@
           "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
           "dev": true,
           "requires": {
-            "postcss": "^5.0.14"
+            "postcss": "5.2.18"
           }
         },
         "postcss-discard-duplicates": {
@@ -6694,7 +6694,7 @@
           "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
           "dev": true,
           "requires": {
-            "postcss": "^5.0.4"
+            "postcss": "5.2.18"
           }
         },
         "postcss-discard-empty": {
@@ -6703,7 +6703,7 @@
           "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
           "dev": true,
           "requires": {
-            "postcss": "^5.0.14"
+            "postcss": "5.2.18"
           }
         },
         "postcss-discard-overridden": {
@@ -6712,7 +6712,7 @@
           "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
           "dev": true,
           "requires": {
-            "postcss": "^5.0.16"
+            "postcss": "5.2.18"
           }
         },
         "postcss-merge-longhand": {
@@ -6721,7 +6721,7 @@
           "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
           "dev": true,
           "requires": {
-            "postcss": "^5.0.4"
+            "postcss": "5.2.18"
           }
         },
         "postcss-merge-rules": {
@@ -6730,11 +6730,11 @@
           "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
           "dev": true,
           "requires": {
-            "browserslist": "^1.5.2",
-            "caniuse-api": "^1.5.2",
-            "postcss": "^5.0.4",
-            "postcss-selector-parser": "^2.2.2",
-            "vendors": "^1.0.0"
+            "browserslist": "1.7.7",
+            "caniuse-api": "1.6.1",
+            "postcss": "5.2.18",
+            "postcss-selector-parser": "2.2.3",
+            "vendors": "1.0.2"
           }
         },
         "postcss-minify-font-values": {
@@ -6743,9 +6743,9 @@
           "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
           "dev": true,
           "requires": {
-            "object-assign": "^4.0.1",
-            "postcss": "^5.0.4",
-            "postcss-value-parser": "^3.0.2"
+            "object-assign": "4.1.1",
+            "postcss": "5.2.18",
+            "postcss-value-parser": "3.3.0"
           }
         },
         "postcss-minify-gradients": {
@@ -6754,8 +6754,8 @@
           "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
           "dev": true,
           "requires": {
-            "postcss": "^5.0.12",
-            "postcss-value-parser": "^3.3.0"
+            "postcss": "5.2.18",
+            "postcss-value-parser": "3.3.0"
           }
         },
         "postcss-minify-params": {
@@ -6764,10 +6764,10 @@
           "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
           "dev": true,
           "requires": {
-            "alphanum-sort": "^1.0.1",
-            "postcss": "^5.0.2",
-            "postcss-value-parser": "^3.0.2",
-            "uniqs": "^2.0.0"
+            "alphanum-sort": "1.0.2",
+            "postcss": "5.2.18",
+            "postcss-value-parser": "3.3.0",
+            "uniqs": "2.0.0"
           }
         },
         "postcss-minify-selectors": {
@@ -6776,10 +6776,10 @@
           "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
           "dev": true,
           "requires": {
-            "alphanum-sort": "^1.0.2",
-            "has": "^1.0.1",
-            "postcss": "^5.0.14",
-            "postcss-selector-parser": "^2.0.0"
+            "alphanum-sort": "1.0.2",
+            "has": "1.0.3",
+            "postcss": "5.2.18",
+            "postcss-selector-parser": "2.2.3"
           }
         },
         "postcss-normalize-charset": {
@@ -6788,7 +6788,7 @@
           "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
           "dev": true,
           "requires": {
-            "postcss": "^5.0.5"
+            "postcss": "5.2.18"
           }
         },
         "postcss-normalize-url": {
@@ -6797,10 +6797,10 @@
           "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
           "dev": true,
           "requires": {
-            "is-absolute-url": "^2.0.0",
-            "normalize-url": "^1.4.0",
-            "postcss": "^5.0.14",
-            "postcss-value-parser": "^3.2.3"
+            "is-absolute-url": "2.1.0",
+            "normalize-url": "1.9.1",
+            "postcss": "5.2.18",
+            "postcss-value-parser": "3.3.0"
           }
         },
         "postcss-ordered-values": {
@@ -6809,8 +6809,8 @@
           "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
           "dev": true,
           "requires": {
-            "postcss": "^5.0.4",
-            "postcss-value-parser": "^3.0.1"
+            "postcss": "5.2.18",
+            "postcss-value-parser": "3.3.0"
           }
         },
         "postcss-reduce-initial": {
@@ -6819,7 +6819,7 @@
           "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
           "dev": true,
           "requires": {
-            "postcss": "^5.0.4"
+            "postcss": "5.2.18"
           }
         },
         "postcss-reduce-transforms": {
@@ -6828,9 +6828,9 @@
           "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
           "dev": true,
           "requires": {
-            "has": "^1.0.1",
-            "postcss": "^5.0.8",
-            "postcss-value-parser": "^3.0.1"
+            "has": "1.0.3",
+            "postcss": "5.2.18",
+            "postcss-value-parser": "3.3.0"
           }
         },
         "postcss-svgo": {
@@ -6839,10 +6839,10 @@
           "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
           "dev": true,
           "requires": {
-            "is-svg": "^2.0.0",
-            "postcss": "^5.0.14",
-            "postcss-value-parser": "^3.2.3",
-            "svgo": "^0.7.0"
+            "is-svg": "2.1.0",
+            "postcss": "5.2.18",
+            "postcss-value-parser": "3.3.0",
+            "svgo": "0.7.2"
           }
         },
         "postcss-unique-selectors": {
@@ -6851,9 +6851,9 @@
           "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
           "dev": true,
           "requires": {
-            "alphanum-sort": "^1.0.1",
-            "postcss": "^5.0.4",
-            "uniqs": "^2.0.0"
+            "alphanum-sort": "1.0.2",
+            "postcss": "5.2.18",
+            "uniqs": "2.0.0"
           }
         },
         "source-map": {
@@ -6868,7 +6868,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         },
         "svgo": {
@@ -6877,13 +6877,13 @@
           "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
           "dev": true,
           "requires": {
-            "coa": "~1.0.1",
-            "colors": "~1.1.2",
-            "csso": "~2.3.1",
-            "js-yaml": "~3.7.0",
-            "mkdirp": "~0.5.1",
-            "sax": "~1.2.1",
-            "whet.extend": "~0.9.9"
+            "coa": "1.0.4",
+            "colors": "1.1.2",
+            "csso": "2.3.2",
+            "js-yaml": "3.7.0",
+            "mkdirp": "0.5.1",
+            "sax": "1.2.4",
+            "whet.extend": "0.9.9"
           }
         }
       }
@@ -6894,9 +6894,9 @@
       "integrity": "sha512-9GUqCqh85C7rP9120cpxXuZz2ayq3BZc85pCTuPJS03VQYxne0aWPIXWx6LSvsGPa3uRqtSO537vaugOh+5cXg==",
       "dev": true,
       "requires": {
-        "eslint": "^5.0.1",
-        "fancy-log": "^1.3.2",
-        "plugin-error": "^1.0.1"
+        "eslint": "5.12.1",
+        "fancy-log": "1.3.2",
+        "plugin-error": "1.0.1"
       }
     },
     "gulp-ext": {
@@ -6905,13 +6905,13 @@
       "integrity": "sha1-vu/w9eh+fY4TXeoGKfpcussQMBY=",
       "dev": true,
       "requires": {
-        "gulp-util": "~2.2.14",
-        "through2": "~0.4.1"
+        "gulp-util": "2.2.20",
+        "through2": "0.4.2"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "0.2.1",
-          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
           "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
           "dev": true
         },
@@ -6923,15 +6923,15 @@
         },
         "chalk": {
           "version": "0.5.1",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^1.1.0",
-            "escape-string-regexp": "^1.0.0",
-            "has-ansi": "^0.1.0",
-            "strip-ansi": "^0.3.0",
-            "supports-color": "^0.2.0"
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
           }
         },
         "dateformat": {
@@ -6940,8 +6940,8 @@
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1",
-            "meow": "^3.3.0"
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
           }
         },
         "gulp-util": {
@@ -6950,14 +6950,14 @@
           "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
           "dev": true,
           "requires": {
-            "chalk": "^0.5.0",
-            "dateformat": "^1.0.7-1.2.3",
-            "lodash._reinterpolate": "^2.4.1",
-            "lodash.template": "^2.4.1",
-            "minimist": "^0.2.0",
-            "multipipe": "^0.1.0",
-            "through2": "^0.5.0",
-            "vinyl": "^0.2.1"
+            "chalk": "0.5.1",
+            "dateformat": "1.0.12",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.template": "2.4.1",
+            "minimist": "0.2.0",
+            "multipipe": "0.1.2",
+            "through2": "0.5.1",
+            "vinyl": "0.2.3"
           },
           "dependencies": {
             "through2": {
@@ -6966,8 +6966,8 @@
               "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
               "dev": true,
               "requires": {
-                "readable-stream": "~1.0.17",
-                "xtend": "~3.0.0"
+                "readable-stream": "1.0.34",
+                "xtend": "3.0.0"
               }
             }
           }
@@ -6978,7 +6978,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.0"
+            "ansi-regex": "0.2.1"
           }
         },
         "isarray": {
@@ -6999,9 +6999,9 @@
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
           "dev": true,
           "requires": {
-            "lodash._escapehtmlchar": "~2.4.1",
-            "lodash._reunescapedhtml": "~2.4.1",
-            "lodash.keys": "~2.4.1"
+            "lodash._escapehtmlchar": "2.4.1",
+            "lodash._reunescapedhtml": "2.4.1",
+            "lodash.keys": "2.4.1"
           }
         },
         "lodash.keys": {
@@ -7010,9 +7010,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         },
         "lodash.template": {
@@ -7021,13 +7021,13 @@
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
           "dev": true,
           "requires": {
-            "lodash._escapestringchar": "~2.4.1",
-            "lodash._reinterpolate": "~2.4.1",
-            "lodash.defaults": "~2.4.1",
-            "lodash.escape": "~2.4.1",
-            "lodash.keys": "~2.4.1",
-            "lodash.templatesettings": "~2.4.1",
-            "lodash.values": "~2.4.1"
+            "lodash._escapestringchar": "2.4.1",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.defaults": "2.4.1",
+            "lodash.escape": "2.4.1",
+            "lodash.keys": "2.4.1",
+            "lodash.templatesettings": "2.4.1",
+            "lodash.values": "2.4.1"
           }
         },
         "lodash.templatesettings": {
@@ -7036,26 +7036,26 @@
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~2.4.1",
-            "lodash.escape": "~2.4.1"
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.escape": "2.4.1"
           }
         },
         "minimist": {
           "version": "0.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
           "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -7066,11 +7066,11 @@
         },
         "strip-ansi": {
           "version": "0.3.0",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.1"
+            "ansi-regex": "0.2.1"
           }
         },
         "supports-color": {
@@ -7085,8 +7085,8 @@
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "dev": true,
           "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~2.1.1"
+            "readable-stream": "1.0.34",
+            "xtend": "2.1.2"
           },
           "dependencies": {
             "xtend": {
@@ -7095,7 +7095,7 @@
               "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
               "dev": true,
               "requires": {
-                "object-keys": "~0.4.0"
+                "object-keys": "0.4.0"
               }
             }
           }
@@ -7106,7 +7106,7 @@
           "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
           "dev": true,
           "requires": {
-            "clone-stats": "~0.0.1"
+            "clone-stats": "0.0.1"
           }
         },
         "xtend": {
@@ -7123,15 +7123,15 @@
       "integrity": "sha1-DsAAv5HoyuQkMF2g+QV68xWDMrA=",
       "dev": true,
       "requires": {
-        "chalk": "^0.5.1",
-        "gulp-util": "^3.0.0",
-        "rename": "^0.2.3",
-        "through2": "^0.5.1"
+        "chalk": "0.5.1",
+        "gulp-util": "3.0.8",
+        "rename": "0.2.3",
+        "through2": "0.5.1"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "0.2.1",
-          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
           "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
           "dev": true
         },
@@ -7143,15 +7143,15 @@
         },
         "chalk": {
           "version": "0.5.1",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^1.1.0",
-            "escape-string-regexp": "^1.0.0",
-            "has-ansi": "^0.1.0",
-            "strip-ansi": "^0.3.0",
-            "supports-color": "^0.2.0"
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
           }
         },
         "has-ansi": {
@@ -7160,7 +7160,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.0"
+            "ansi-regex": "0.2.1"
           }
         },
         "isarray": {
@@ -7171,14 +7171,14 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -7189,11 +7189,11 @@
         },
         "strip-ansi": {
           "version": "0.3.0",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^0.2.1"
+            "ansi-regex": "0.2.1"
           }
         },
         "supports-color": {
@@ -7208,8 +7208,8 @@
           "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
           "dev": true,
           "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~3.0.0"
+            "readable-stream": "1.0.34",
+            "xtend": "3.0.0"
           }
         },
         "xtend": {
@@ -7226,11 +7226,11 @@
       "integrity": "sha512-Wtl6vH7a+8IS/fU5W9IbOpcaLqKxd5L1DUOzaPmlnCbX1CrG0aWdwVnC3Spn8th0m8D59YbysV5zPUe1n/GJYg==",
       "dev": true,
       "requires": {
-        "fancy-log": "^1.3.2",
-        "plugin-error": "^1.0.1",
-        "postcss": "^7.0.2",
-        "postcss-load-config": "^2.0.0",
-        "vinyl-sourcemaps-apply": "^0.2.1"
+        "fancy-log": "1.3.2",
+        "plugin-error": "1.0.1",
+        "postcss": "7.0.14",
+        "postcss-load-config": "2.0.0",
+        "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
         "chalk": {
@@ -7239,9 +7239,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -7250,7 +7250,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -7261,9 +7261,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -7272,7 +7272,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -7289,13 +7289,13 @@
       "integrity": "sha1-yxrI5rqD3t5SQwxH/QOTJPAD/4I=",
       "dev": true,
       "requires": {
-        "chalk": "^2.3.0",
-        "fancy-log": "^1.3.2",
-        "gzip-size": "^4.1.0",
-        "plugin-error": "^0.1.2",
-        "pretty-bytes": "^4.0.2",
-        "stream-counter": "^1.0.0",
-        "through2": "^2.0.0"
+        "chalk": "2.4.1",
+        "fancy-log": "1.3.2",
+        "gzip-size": "4.1.0",
+        "plugin-error": "0.1.2",
+        "pretty-bytes": "4.0.2",
+        "stream-counter": "1.0.0",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "arr-diff": {
@@ -7304,8 +7304,8 @@
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1",
-            "array-slice": "^0.2.3"
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
           }
         },
         "arr-union": {
@@ -7326,7 +7326,7 @@
           "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
           "dev": true,
           "requires": {
-            "kind-of": "^1.1.0"
+            "kind-of": "1.1.0"
           }
         },
         "kind-of": {
@@ -7341,11 +7341,11 @@
           "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
           "dev": true,
           "requires": {
-            "ansi-cyan": "^0.1.1",
-            "ansi-red": "^0.1.1",
-            "arr-diff": "^1.0.1",
-            "arr-union": "^2.0.1",
-            "extend-shallow": "^1.1.2"
+            "ansi-cyan": "0.1.1",
+            "ansi-red": "0.1.1",
+            "arr-diff": "1.1.0",
+            "arr-union": "2.1.0",
+            "extend-shallow": "1.1.4"
           }
         }
       }
@@ -7356,17 +7356,17 @@
       "integrity": "sha1-y7IAhFCxvM5s0jv5gze+dRv24wo=",
       "dev": true,
       "requires": {
-        "@gulp-sourcemaps/identity-map": "1.X",
-        "@gulp-sourcemaps/map-sources": "1.X",
-        "acorn": "5.X",
-        "convert-source-map": "1.X",
-        "css": "2.X",
-        "debug-fabulous": "1.X",
-        "detect-newline": "2.X",
-        "graceful-fs": "4.X",
-        "source-map": "~0.6.0",
-        "strip-bom-string": "1.X",
-        "through2": "2.X"
+        "@gulp-sourcemaps/identity-map": "1.0.2",
+        "@gulp-sourcemaps/map-sources": "1.0.0",
+        "acorn": "5.7.3",
+        "convert-source-map": "1.6.0",
+        "css": "2.2.4",
+        "debug-fabulous": "1.1.0",
+        "detect-newline": "2.1.0",
+        "graceful-fs": "4.1.11",
+        "source-map": "0.6.1",
+        "strip-bom-string": "1.0.0",
+        "through2": "2.0.3"
       }
     },
     "gulp-svgmin": {
@@ -7375,8 +7375,8 @@
       "integrity": "sha512-Borxf8zucgfqF+bzJDz10YDkAS9zhKVHf/FhgHdjgD4+PnvyETCJWaeumg7j8ilCdAJsoMs8dS9TpHwI2hfbUQ==",
       "dev": true,
       "requires": {
-        "plugin-error": "^1.0.1",
-        "svgo": "^1.1.1"
+        "plugin-error": "1.0.1",
+        "svgo": "1.1.1"
       }
     },
     "gulp-util": {
@@ -7385,24 +7385,24 @@
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-uniq": "^1.0.2",
-        "beeper": "^1.0.0",
-        "chalk": "^1.0.0",
-        "dateformat": "^2.0.0",
-        "fancy-log": "^1.1.0",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "lodash._reescape": "^3.0.0",
-        "lodash._reevaluate": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.template": "^3.0.0",
-        "minimist": "^1.1.0",
-        "multipipe": "^0.1.2",
-        "object-assign": "^3.0.0",
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "^2.0.0",
-        "vinyl": "^0.5.0"
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7413,20 +7413,20 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -7451,17 +7451,17 @@
       "dev": true,
       "requires": {
         "ansi-colors": "1.1.0",
-        "anymatch": "^1.3.0",
-        "chokidar": "^2.0.0",
+        "anymatch": "1.3.2",
+        "chokidar": "2.0.4",
         "fancy-log": "1.3.2",
-        "glob-parent": "^3.0.1",
-        "object-assign": "^4.1.0",
-        "path-is-absolute": "^1.0.1",
+        "glob-parent": "3.1.0",
+        "object-assign": "4.1.1",
+        "path-is-absolute": "1.0.1",
         "plugin-error": "1.0.1",
-        "readable-stream": "^2.2.2",
-        "slash": "^1.0.0",
-        "vinyl": "^2.1.0",
-        "vinyl-file": "^2.0.0"
+        "readable-stream": "2.3.6",
+        "slash": "1.0.0",
+        "vinyl": "2.2.0",
+        "vinyl-file": "2.0.0"
       },
       "dependencies": {
         "arr-diff": {
@@ -7482,16 +7482,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -7500,7 +7500,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7511,19 +7511,19 @@
           "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
           "dev": true,
           "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.0",
-            "braces": "^2.3.0",
-            "fsevents": "^1.2.2",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.1",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "lodash.debounce": "^4.0.8",
-            "normalize-path": "^2.1.1",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.0.0",
-            "upath": "^1.0.5"
+            "anymatch": "2.0.0",
+            "async-each": "1.0.1",
+            "braces": "2.3.2",
+            "fsevents": "1.2.4",
+            "glob-parent": "3.1.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "4.0.0",
+            "lodash.debounce": "4.0.8",
+            "normalize-path": "2.1.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.2.1",
+            "upath": "1.1.0"
           },
           "dependencies": {
             "anymatch": {
@@ -7532,8 +7532,8 @@
               "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
               "dev": true,
               "requires": {
-                "micromatch": "^3.1.4",
-                "normalize-path": "^2.1.1"
+                "micromatch": "3.1.10",
+                "normalize-path": "2.1.1"
               }
             }
           }
@@ -7556,13 +7556,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -7571,7 +7571,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -7580,7 +7580,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -7589,7 +7589,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -7598,7 +7598,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -7609,7 +7609,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -7618,7 +7618,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -7629,9 +7629,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -7648,14 +7648,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -7664,7 +7664,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -7673,7 +7673,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7684,10 +7684,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -7696,7 +7696,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -7707,8 +7707,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -7717,7 +7717,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -7728,7 +7728,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -7737,7 +7737,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -7746,9 +7746,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-extglob": {
@@ -7763,7 +7763,7 @@
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-number": {
@@ -7772,7 +7772,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7781,7 +7781,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -7804,19 +7804,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "replace-ext": {
@@ -7831,12 +7831,12 @@
           "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.2",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.2",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -7847,7 +7847,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "^1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "gzip-size": {
@@ -7856,8 +7856,8 @@
       "integrity": "sha1-iuCWJX6r59acRb4rZ8RIEk/7UXw=",
       "dev": true,
       "requires": {
-        "duplexer": "^0.1.1",
-        "pify": "^3.0.0"
+        "duplexer": "0.1.1",
+        "pify": "3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -7880,8 +7880,8 @@
       "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "dev": true,
       "requires": {
-        "ajv": "^5.3.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has": {
@@ -7890,7 +7890,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -7899,7 +7899,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-binary2": {
@@ -7929,7 +7929,7 @@
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.1"
       }
     },
     "has-symbols": {
@@ -7944,9 +7944,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -7963,8 +7963,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -7973,7 +7973,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7982,7 +7982,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -7993,7 +7993,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -8010,8 +8010,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "homedir-polyfill": {
@@ -8020,7 +8020,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -8059,12 +8059,12 @@
       "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.0",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.0.6"
+        "domelementtype": "1.3.0",
+        "domhandler": "2.4.2",
+        "domutils": "1.7.0",
+        "entities": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "3.1.1"
       },
       "dependencies": {
         "readable-stream": {
@@ -8073,23 +8073,23 @@
           "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "inherits": "2.0.3",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         }
       }
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
+        "statuses": "1.5.0"
       },
       "dependencies": {
         "statuses": {
@@ -8106,8 +8106,8 @@
       "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
       "dev": true,
       "requires": {
-        "eventemitter3": "1.x.x",
-        "requires-port": "1.x.x"
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
       }
     },
     "http-signature": {
@@ -8116,9 +8116,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
       }
     },
     "humanize-url": {
@@ -8127,8 +8127,8 @@
       "integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
       "dev": true,
       "requires": {
-        "normalize-url": "^1.0.0",
-        "strip-url-auth": "^1.0.0"
+        "normalize-url": "1.9.1",
+        "strip-url-auth": "1.0.1"
       },
       "dependencies": {
         "normalize-url": {
@@ -8137,10 +8137,10 @@
           "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
           "dev": true,
           "requires": {
-            "object-assign": "^4.0.1",
-            "prepend-http": "^1.0.0",
-            "query-string": "^4.1.0",
-            "sort-keys": "^1.0.0"
+            "object-assign": "4.1.1",
+            "prepend-http": "1.0.4",
+            "query-string": "4.3.4",
+            "sort-keys": "1.1.2"
           }
         }
       }
@@ -8151,8 +8151,8 @@
       "integrity": "sha1-PRoMXYMpW83lx1qXjdquQJb4PAI=",
       "dev": true,
       "requires": {
-        "duplexer2": "~0.0.2",
-        "through2": "~0.6.3"
+        "duplexer2": "0.0.2",
+        "through2": "0.6.5"
       },
       "dependencies": {
         "isarray": {
@@ -8163,14 +8163,14 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -8185,8 +8185,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -8197,7 +8197,7 @@
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ignore": {
@@ -8218,7 +8218,7 @@
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "dev": true,
       "requires": {
-        "import-from": "^2.1.0"
+        "import-from": "2.1.0"
       }
     },
     "import-fresh": {
@@ -8227,8 +8227,8 @@
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "dev": true,
       "requires": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
+        "caller-path": "2.0.0",
+        "resolve-from": "3.0.0"
       }
     },
     "import-from": {
@@ -8237,7 +8237,7 @@
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       }
     },
     "import-lazy": {
@@ -8258,7 +8258,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "indexes-of": {
@@ -8279,8 +8279,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -8301,19 +8301,19 @@
       "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.11",
+        "ansi-escapes": "3.2.0",
+        "chalk": "2.4.2",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "3.0.3",
+        "figures": "2.0.0",
+        "lodash": "4.17.11",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^5.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rxjs": "6.4.0",
+        "string-width": "2.1.1",
+        "strip-ansi": "5.0.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -8334,9 +8334,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -8351,7 +8351,7 @@
           "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
           "dev": true,
           "requires": {
-            "tslib": "^1.9.0"
+            "tslib": "1.9.3"
           }
         },
         "string-width": {
@@ -8360,8 +8360,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
             "strip-ansi": {
@@ -8370,7 +8370,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -8381,7 +8381,7 @@
           "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -8406,7 +8406,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
@@ -8421,8 +8421,8 @@
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.2"
       }
     },
     "is-absolute-url": {
@@ -8437,7 +8437,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-alphabetical": {
@@ -8458,8 +8458,8 @@
       "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
       "dev": true,
       "requires": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
+        "is-alphabetical": "1.0.2",
+        "is-decimal": "1.0.2"
       }
     },
     "is-arrayish": {
@@ -8474,7 +8474,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.12.0"
       }
     },
     "is-buffer": {
@@ -8485,11 +8485,11 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-callable": {
@@ -8504,7 +8504,7 @@
       "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.5.0"
+        "ci-info": "1.6.0"
       }
     },
     "is-color-stop": {
@@ -8513,12 +8513,12 @@
       "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
       "dev": true,
       "requires": {
-        "css-color-names": "^0.0.4",
-        "hex-color-regex": "^1.1.0",
-        "hsl-regex": "^1.0.0",
-        "hsla-regex": "^1.0.0",
-        "rgb-regex": "^1.0.1",
-        "rgba-regex": "^1.0.0"
+        "css-color-names": "0.0.4",
+        "hex-color-regex": "1.1.0",
+        "hsl-regex": "1.0.0",
+        "hsla-regex": "1.0.0",
+        "rgb-regex": "1.0.1",
+        "rgba-regex": "1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -8527,7 +8527,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-date-object": {
@@ -8548,9 +8548,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -8579,7 +8579,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -8600,7 +8600,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -8609,7 +8609,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-glob": {
@@ -8618,7 +8618,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-hexadecimal": {
@@ -8633,8 +8633,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.1"
       }
     },
     "is-module": {
@@ -8661,7 +8661,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-number-like": {
@@ -8670,12 +8670,12 @@
       "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
       "dev": true,
       "requires": {
-        "lodash.isfinite": "^3.3.2"
+        "lodash.isfinite": "3.3.2"
       }
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -8685,7 +8685,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -8700,7 +8700,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -8741,7 +8741,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
     },
     "is-regexp": {
@@ -8756,7 +8756,7 @@
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
-        "is-unc-path": "^1.0.0"
+        "is-unc-path": "1.0.0"
       }
     },
     "is-resolvable": {
@@ -8789,7 +8789,7 @@
       "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
       "dev": true,
       "requires": {
-        "html-comment-regex": "^1.1.0"
+        "html-comment-regex": "1.1.2"
       }
     },
     "is-symbol": {
@@ -8798,7 +8798,7 @@
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "1.0.0"
       }
     },
     "is-typedarray": {
@@ -8813,7 +8813,7 @@
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
-        "unc-path-regex": "^0.1.2"
+        "unc-path-regex": "0.1.2"
       }
     },
     "is-url": {
@@ -8905,8 +8905,8 @@
       "integrity": "sha512-s64/OThpfQvoCeHG963MiEZOAAxu8kHsaL/rCMF7lpdzo7vgF0CtPml9hfguOMgykgH/eOm4jFP4ibfHLruytg==",
       "dev": true,
       "requires": {
-        "merge-stream": "^1.0.1",
-        "supports-color": "^6.1.0"
+        "merge-stream": "1.0.1",
+        "supports-color": "6.1.0"
       },
       "dependencies": {
         "supports-color": {
@@ -8915,7 +8915,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -8938,8 +8938,8 @@
       "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "jsbn": {
@@ -8987,7 +8987,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -8997,7 +8997,7 @@
       "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsprim": {
@@ -9024,7 +9024,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "known-css-properties": {
@@ -9039,8 +9039,8 @@
       "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
       "dev": true,
       "requires": {
-        "default-resolution": "^2.0.0",
-        "es6-weak-map": "^2.0.1"
+        "default-resolution": "2.0.0",
+        "es6-weak-map": "2.0.2"
       }
     },
     "latest-version": {
@@ -9049,7 +9049,7 @@
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
-        "package-json": "^4.0.0"
+        "package-json": "4.0.1"
       }
     },
     "lazystream": {
@@ -9058,7 +9058,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "2.3.6"
       }
     },
     "lcid": {
@@ -9067,7 +9067,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "lead": {
@@ -9076,7 +9076,7 @@
       "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
       "dev": true,
       "requires": {
-        "flush-write-stream": "^1.0.2"
+        "flush-write-stream": "1.0.3"
       }
     },
     "leven": {
@@ -9091,8 +9091,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "liftoff": {
@@ -9101,14 +9101,14 @@
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
-        "fined": "^1.0.1",
-        "flagged-respawn": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "object.map": "^1.0.0",
-        "rechoir": "^0.6.2",
-        "resolve": "^1.1.7"
+        "extend": "3.0.2",
+        "findup-sync": "2.0.0",
+        "fined": "1.1.1",
+        "flagged-respawn": "1.0.1",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.8.1"
       }
     },
     "limiter": {
@@ -9125,20 +9125,20 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       }
     },
     "localtunnel": {
       "version": "1.9.0",
-      "resolved": "http://registry.npmjs.org/localtunnel/-/localtunnel-1.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.0.tgz",
       "integrity": "sha512-wCIiIHJ8kKIcWkTQE3m1VRABvsH2ZuOkiOpZUofUCf6Q42v3VIZ+Q0YfX1Z4sYDRj0muiKL1bLvz1FeoxsPO0w==",
       "dev": true,
       "requires": {
@@ -9159,23 +9159,23 @@
         },
         "yargs": {
           "version": "6.6.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^4.2.0"
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
           }
         }
       }
@@ -9186,8 +9186,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -9228,7 +9228,7 @@
       "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
       "dev": true,
       "requires": {
-        "lodash._htmlescapes": "~2.4.1"
+        "lodash._htmlescapes": "2.4.1"
       }
     },
     "lodash._escapestringchar": {
@@ -9291,8 +9291,8 @@
       "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
       "dev": true,
       "requires": {
-        "lodash._htmlescapes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
+        "lodash._htmlescapes": "2.4.1",
+        "lodash.keys": "2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -9301,9 +9301,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         }
       }
@@ -9320,7 +9320,7 @@
       "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "~2.4.1"
+        "lodash._objecttypes": "2.4.1"
       }
     },
     "lodash.debounce": {
@@ -9335,8 +9335,8 @@
       "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "~2.4.1",
-        "lodash.keys": "~2.4.1"
+        "lodash._objecttypes": "2.4.1",
+        "lodash.keys": "2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -9345,9 +9345,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         }
       }
@@ -9358,7 +9358,7 @@
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "dev": true,
       "requires": {
-        "lodash._root": "^3.0.0"
+        "lodash._root": "3.0.1"
       }
     },
     "lodash.isarguments": {
@@ -9385,7 +9385,7 @@
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "~2.4.1"
+        "lodash._objecttypes": "2.4.1"
       }
     },
     "lodash.keys": {
@@ -9394,9 +9394,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash.memoize": {
@@ -9417,15 +9417,15 @@
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash._basetostring": "^3.0.0",
-        "lodash._basevalues": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0",
-        "lodash.keys": "^3.0.0",
-        "lodash.restparam": "^3.0.0",
-        "lodash.templatesettings": "^3.0.0"
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
       }
     },
     "lodash.templatesettings": {
@@ -9434,8 +9434,8 @@
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
       }
     },
     "lodash.uniq": {
@@ -9450,7 +9450,7 @@
       "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
       "dev": true,
       "requires": {
-        "lodash.keys": "~2.4.1"
+        "lodash.keys": "2.4.1"
       },
       "dependencies": {
         "lodash.keys": {
@@ -9459,9 +9459,9 @@
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
           "dev": true,
           "requires": {
-            "lodash._isnative": "~2.4.1",
-            "lodash._shimkeys": "~2.4.1",
-            "lodash.isobject": "~2.4.1"
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
           }
         }
       }
@@ -9472,7 +9472,7 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "2.4.1"
       }
     },
     "longest-streak": {
@@ -9487,7 +9487,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "loud-rejection": {
@@ -9496,8 +9496,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lowercase-keys": {
@@ -9512,8 +9512,8 @@
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "lru-queue": {
@@ -9522,16 +9522,16 @@
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "dev": true,
       "requires": {
-        "es5-ext": "~0.10.2"
+        "es5-ext": "0.10.46"
       }
     },
     "magic-string": {
       "version": "0.22.5",
-      "resolved": "http://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
       "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "dev": true,
       "requires": {
-        "vlq": "^0.2.2"
+        "vlq": "0.2.3"
       }
     },
     "make-dir": {
@@ -9540,7 +9540,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -9557,7 +9557,7 @@
       "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "dev": true,
       "requires": {
-        "kind-of": "^6.0.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -9586,7 +9586,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "markdown-escapes": {
@@ -9607,9 +9607,9 @@
       "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
       "dev": true,
       "requires": {
-        "findup-sync": "^2.0.0",
-        "micromatch": "^3.0.4",
-        "resolve": "^1.4.0",
+        "findup-sync": "2.0.0",
+        "micromatch": "3.1.10",
+        "resolve": "1.8.1",
         "stack-trace": "0.0.10"
       },
       "dependencies": {
@@ -9631,16 +9631,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -9649,7 +9649,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -9660,13 +9660,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -9675,7 +9675,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -9684,7 +9684,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -9693,7 +9693,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -9702,7 +9702,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -9713,7 +9713,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -9722,7 +9722,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -9733,9 +9733,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -9752,14 +9752,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -9768,7 +9768,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -9777,7 +9777,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -9788,10 +9788,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -9800,7 +9800,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -9811,7 +9811,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -9820,7 +9820,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -9829,9 +9829,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-number": {
@@ -9840,7 +9840,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9849,7 +9849,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -9872,19 +9872,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -9913,7 +9913,7 @@
       "integrity": "sha512-d2WS98JSDVbpSsBfVvD9TaDMlqPRz7ohM/11G0rp5jOBb5q96RJ6YLszQ/09AAixyzh23FeIpCGqfaamEADtWg==",
       "dev": true,
       "requires": {
-        "unist-util-visit": "^1.1.0"
+        "unist-util-visit": "1.4.0"
       }
     },
     "mdn-data": {
@@ -9928,14 +9928,14 @@
       "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.45",
-        "es6-weak-map": "^2.0.2",
-        "event-emitter": "^0.3.5",
-        "is-promise": "^2.1",
-        "lru-queue": "0.1",
-        "next-tick": "1",
-        "timers-ext": "^0.1.5"
+        "d": "1.0.0",
+        "es5-ext": "0.10.46",
+        "es6-weak-map": "2.0.2",
+        "event-emitter": "0.3.5",
+        "is-promise": "2.1.0",
+        "lru-queue": "0.1.0",
+        "next-tick": "1.0.0",
+        "timers-ext": "0.1.5"
       }
     },
     "meow": {
@@ -9944,21 +9944,21 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -9970,7 +9970,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       }
     },
     "merge2": {
@@ -9985,19 +9985,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "mime": {
@@ -10018,7 +10018,7 @@
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.36.0"
+        "mime-db": "1.36.0"
       }
     },
     "mimic-fn": {
@@ -10033,12 +10033,12 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -10048,8 +10048,8 @@
       "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
+        "arrify": "1.0.1",
+        "is-plain-obj": "1.1.0"
       }
     },
     "mixin-deep": {
@@ -10058,8 +10058,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -10068,14 +10068,14 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -10122,17 +10122,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -10185,7 +10185,7 @@
       "integrity": "sha512-lODUVHEIZutZx+TDdOk47qLik8FJMXzJ+WnyUGci1MTvTOyzZrz5eVPIIpc5Hb3NfHZGeGHeuwrRYVI1PEITWg==",
       "dev": true,
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "5.5.1"
       }
     },
     "normalize-package-data": {
@@ -10194,10 +10194,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.1",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "normalize-path": {
@@ -10206,7 +10206,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "normalize-range": {
@@ -10233,7 +10233,7 @@
       "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
       "dev": true,
       "requires": {
-        "once": "^1.3.2"
+        "once": "1.4.0"
       }
     },
     "npm-run-path": {
@@ -10242,7 +10242,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "nth-check": {
@@ -10251,7 +10251,7 @@
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "dev": true,
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "1.0.0"
       }
     },
     "num2fraction": {
@@ -10290,9 +10290,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -10301,7 +10301,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -10324,7 +10324,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -10341,10 +10341,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
+        "object-keys": "1.0.12"
       },
       "dependencies": {
         "object-keys": {
@@ -10361,10 +10361,10 @@
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
       "requires": {
-        "array-each": "^1.0.1",
-        "array-slice": "^1.0.0",
-        "for-own": "^1.0.0",
-        "isobject": "^3.0.0"
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -10373,7 +10373,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         },
         "isobject": {
@@ -10390,8 +10390,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.12.0"
       }
     },
     "object.map": {
@@ -10400,8 +10400,8 @@
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "dev": true,
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -10410,7 +10410,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -10421,8 +10421,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -10431,7 +10431,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "isobject": {
@@ -10448,8 +10448,8 @@
       "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
       "dev": true,
       "requires": {
-        "for-own": "^1.0.0",
-        "make-iterator": "^1.0.0"
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
       },
       "dependencies": {
         "for-own": {
@@ -10458,7 +10458,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         }
       }
@@ -10469,10 +10469,10 @@
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3"
       }
     },
     "on-finished": {
@@ -10490,7 +10490,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -10499,7 +10499,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "openurl": {
@@ -10514,7 +10514,7 @@
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "dev": true,
       "requires": {
-        "is-wsl": "^1.1.0"
+        "is-wsl": "1.1.0"
       }
     },
     "optionator": {
@@ -10523,12 +10523,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "ordered-read-streams": {
@@ -10537,7 +10537,7 @@
       "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       }
     },
     "os-homedir": {
@@ -10548,11 +10548,11 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-shim": {
@@ -10579,7 +10579,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -10588,7 +10588,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.3.0"
       }
     },
     "p-try": {
@@ -10603,10 +10603,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.5.1"
       }
     },
     "parent-module": {
@@ -10615,7 +10615,7 @@
       "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
       "dev": true,
       "requires": {
-        "callsites": "^3.0.0"
+        "callsites": "3.0.0"
       },
       "dependencies": {
         "callsites": {
@@ -10632,12 +10632,12 @@
       "integrity": "sha512-XXtDdOPLSB0sHecbEapQi6/58U/ODj/KWfIXmmMCJF/eRn8laX6LZbOyioMoETOOJoWRW8/qTSl5VQkUIfKM5g==",
       "dev": true,
       "requires": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "character-entities": "1.2.2",
+        "character-entities-legacy": "1.1.2",
+        "character-reference-invalid": "1.1.2",
+        "is-alphanumerical": "1.0.2",
+        "is-decimal": "1.0.2",
+        "is-hexadecimal": "1.0.2"
       }
     },
     "parse-filepath": {
@@ -10646,9 +10646,9 @@
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "requires": {
-        "is-absolute": "^1.0.0",
-        "map-cache": "^0.2.0",
-        "path-root": "^0.1.1"
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
       }
     },
     "parse-glob": {
@@ -10657,10 +10657,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-json": {
@@ -10669,7 +10669,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.2"
       }
     },
     "parse-passwd": {
@@ -10684,7 +10684,7 @@
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseuri": {
@@ -10693,7 +10693,7 @@
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "~1.0.0"
+        "better-assert": "1.0.2"
       }
     },
     "parseurl": {
@@ -10720,7 +10720,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^2.0.0"
+        "pinkie-promise": "2.0.1"
       }
     },
     "path-is-absolute": {
@@ -10753,7 +10753,7 @@
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
-        "path-root-regex": "^0.1.0"
+        "path-root-regex": "0.1.2"
       }
     },
     "path-root-regex": {
@@ -10768,9 +10768,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "performance-now": {
@@ -10797,7 +10797,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "plugin-error": {
@@ -10806,10 +10806,10 @@
       "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
       "dev": true,
       "requires": {
-        "ansi-colors": "^1.0.1",
-        "arr-diff": "^4.0.0",
-        "arr-union": "^3.1.0",
-        "extend-shallow": "^3.0.2"
+        "ansi-colors": "1.1.0",
+        "arr-diff": "4.0.0",
+        "arr-union": "3.1.0",
+        "extend-shallow": "3.0.2"
       },
       "dependencies": {
         "arr-diff": {
@@ -10833,7 +10833,7 @@
       "dev": true,
       "requires": {
         "async": "1.5.2",
-        "is-number-like": "^1.0.3"
+        "is-number-like": "1.0.8"
       }
     },
     "posix-character-classes": {
@@ -10848,9 +10848,9 @@
       "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
+        "chalk": "2.4.1",
+        "source-map": "0.6.1",
+        "supports-color": "5.5.0"
       }
     },
     "postcss-apply": {
@@ -10859,9 +10859,9 @@
       "integrity": "sha1-FOVEu7XLbxweBIhXll15rgZrE0M=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.23.0",
-        "balanced-match": "^0.4.2",
-        "postcss": "^6.0.0"
+        "babel-runtime": "6.26.0",
+        "balanced-match": "0.4.2",
+        "postcss": "6.0.23"
       },
       "dependencies": {
         "balanced-match": {
@@ -10878,8 +10878,8 @@
       "integrity": "sha1-lNxCLI+QmX8WvTOjZUu77AhJY7Q=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.0",
-        "postcss-selector-parser": "^2.2.3"
+        "postcss": "6.0.23",
+        "postcss-selector-parser": "2.2.3"
       }
     },
     "postcss-calc": {
@@ -10888,10 +10888,10 @@
       "integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
       "dev": true,
       "requires": {
-        "css-unit-converter": "^1.1.1",
-        "postcss": "^7.0.5",
-        "postcss-selector-parser": "^5.0.0-rc.4",
-        "postcss-value-parser": "^3.3.1"
+        "css-unit-converter": "1.1.1",
+        "postcss": "7.0.14",
+        "postcss-selector-parser": "5.0.0",
+        "postcss-value-parser": "3.3.1"
       },
       "dependencies": {
         "chalk": {
@@ -10900,9 +10900,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -10911,7 +10911,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -10922,9 +10922,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "postcss-selector-parser": {
@@ -10933,9 +10933,9 @@
           "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
           "dev": true,
           "requires": {
-            "cssesc": "^2.0.0",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "cssesc": "2.0.0",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         },
         "postcss-value-parser": {
@@ -10950,7 +10950,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -10961,10 +10961,10 @@
       "integrity": "sha1-QCs/LOvD9pR+YY+2vjZU++zvZEQ=",
       "dev": true,
       "requires": {
-        "css-color-function": "~1.3.3",
-        "postcss": "^6.0.1",
-        "postcss-message-helpers": "^2.0.0",
-        "postcss-value-parser": "^3.3.0"
+        "css-color-function": "1.3.3",
+        "postcss": "6.0.23",
+        "postcss-message-helpers": "2.0.0",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-color-gray": {
@@ -10973,10 +10973,10 @@
       "integrity": "sha512-L4iLKQLdqChz6ZOgGb6dRxkBNw78JFYcJmBz1orHpZoeLtuhDDGegRtX9gSyfoCIM7rWZ3VNOyiqqvk83BEN+w==",
       "dev": true,
       "requires": {
-        "color": "^2.0.1",
-        "postcss": "^6.0.14",
-        "postcss-message-helpers": "^2.0.0",
-        "reduce-function-call": "^1.0.2"
+        "color": "2.0.1",
+        "postcss": "6.0.23",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-function-call": "1.0.2"
       },
       "dependencies": {
         "color": {
@@ -10985,8 +10985,8 @@
           "integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.1",
-            "color-string": "^1.5.2"
+            "color-convert": "1.9.3",
+            "color-string": "1.5.3"
           }
         },
         "color-string": {
@@ -10995,8 +10995,8 @@
           "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
           "dev": true,
           "requires": {
-            "color-name": "^1.0.0",
-            "simple-swizzle": "^0.2.2"
+            "color-name": "1.1.3",
+            "simple-swizzle": "0.2.2"
           }
         }
       }
@@ -11007,9 +11007,9 @@
       "integrity": "sha1-HlPmyKyyN5Vej9CLfs2xuLgwn5U=",
       "dev": true,
       "requires": {
-        "color": "^1.0.3",
-        "postcss": "^6.0.1",
-        "postcss-message-helpers": "^2.0.0"
+        "color": "1.0.3",
+        "postcss": "6.0.23",
+        "postcss-message-helpers": "2.0.0"
       },
       "dependencies": {
         "color": {
@@ -11018,8 +11018,8 @@
           "integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
           "dev": true,
           "requires": {
-            "color-convert": "^1.8.2",
-            "color-string": "^1.4.0"
+            "color-convert": "1.9.3",
+            "color-string": "1.5.3"
           }
         },
         "color-string": {
@@ -11028,8 +11028,8 @@
           "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
           "dev": true,
           "requires": {
-            "color-name": "^1.0.0",
-            "simple-swizzle": "^0.2.2"
+            "color-name": "1.1.3",
+            "simple-swizzle": "0.2.2"
           }
         }
       }
@@ -11040,9 +11040,9 @@
       "integrity": "sha1-EnA2ZvoxBDDj8wpFTawThjF9WEQ=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1",
-        "postcss-value-parser": "^3.3.0",
-        "units-css": "^0.4.0"
+        "postcss": "6.0.23",
+        "postcss-value-parser": "3.3.0",
+        "units-css": "0.4.0"
       }
     },
     "postcss-color-hwb": {
@@ -11051,10 +11051,10 @@
       "integrity": "sha1-NAKxnvTYSXVAwftQcr6YY8qVVx4=",
       "dev": true,
       "requires": {
-        "color": "^1.0.3",
-        "postcss": "^6.0.1",
-        "postcss-message-helpers": "^2.0.0",
-        "reduce-function-call": "^1.0.2"
+        "color": "1.0.3",
+        "postcss": "6.0.23",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-function-call": "1.0.2"
       },
       "dependencies": {
         "color": {
@@ -11063,8 +11063,8 @@
           "integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
           "dev": true,
           "requires": {
-            "color-convert": "^1.8.2",
-            "color-string": "^1.4.0"
+            "color-convert": "1.9.3",
+            "color-string": "1.5.3"
           }
         },
         "color-string": {
@@ -11073,8 +11073,8 @@
           "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
           "dev": true,
           "requires": {
-            "color-name": "^1.0.0",
-            "simple-swizzle": "^0.2.2"
+            "color-name": "1.1.3",
+            "simple-swizzle": "0.2.2"
           }
         }
       }
@@ -11085,8 +11085,8 @@
       "integrity": "sha512-212hJUk9uSsbwO5ECqVjmh/iLsmiVL1xy9ce9TVf+X3cK/ZlUIlaMdoxje/YpsL9cmUH3I7io+/G2LyWx5rg1g==",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.22",
-        "postcss-values-parser": "^1.5.0"
+        "postcss": "6.0.23",
+        "postcss-values-parser": "1.5.0"
       }
     },
     "postcss-color-rgb": {
@@ -11095,8 +11095,8 @@
       "integrity": "sha1-FFOcinExSUtILg3RzCZf9lFLUmM=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1",
-        "postcss-value-parser": "^3.3.0"
+        "postcss": "6.0.23",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-colormin": {
@@ -11105,11 +11105,11 @@
       "integrity": "sha512-1QJc2coIehnVFsz0otges8kQLsryi4lo19WD+U5xCWvXd0uw/Z+KKYnbiNDCnO9GP+PvErPHCG0jNvWTngk9Rw==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
-        "color": "^3.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "browserslist": "4.4.1",
+        "color": "3.1.0",
+        "has": "1.0.3",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "browserslist": {
@@ -11118,9 +11118,9 @@
           "integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000929",
-            "electron-to-chromium": "^1.3.103",
-            "node-releases": "^1.1.3"
+            "caniuse-lite": "1.0.30000933",
+            "electron-to-chromium": "1.3.110",
+            "node-releases": "1.1.6"
           }
         },
         "caniuse-lite": {
@@ -11135,9 +11135,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -11146,7 +11146,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -11157,8 +11157,8 @@
           "integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.1",
-            "color-string": "^1.5.2"
+            "color-convert": "1.9.3",
+            "color-string": "1.5.3"
           }
         },
         "color-string": {
@@ -11167,8 +11167,8 @@
           "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
           "dev": true,
           "requires": {
-            "color-name": "^1.0.0",
-            "simple-swizzle": "^0.2.2"
+            "color-name": "1.1.3",
+            "simple-swizzle": "0.2.2"
           }
         },
         "electron-to-chromium": {
@@ -11183,9 +11183,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -11194,7 +11194,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -11205,8 +11205,8 @@
       "integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -11215,9 +11215,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -11226,7 +11226,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -11237,9 +11237,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -11248,7 +11248,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -11259,17 +11259,17 @@
       "integrity": "sha1-vlMnhBEOyylQRPtTlaGABushpzc=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.23"
       }
     },
     "postcss-custom-properties": {
       "version": "6.3.1",
-      "resolved": "http://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-6.3.1.tgz",
       "integrity": "sha512-zoiwn4sCiUFbr4KcgcNZLFkR6gVQom647L+z1p/KBVHZ1OYwT87apnS42atJtx6XlX2yI7N5fjXbFixShQO2QQ==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
-        "postcss": "^6.0.18"
+        "balanced-match": "1.0.0",
+        "postcss": "6.0.23"
       }
     },
     "postcss-custom-selectors": {
@@ -11278,8 +11278,8 @@
       "integrity": "sha1-eBOC+UxS5yfvXKR3bqKt9JphE4I=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1",
-        "postcss-selector-matches": "^3.0.0"
+        "postcss": "6.0.23",
+        "postcss-selector-matches": "3.0.1"
       }
     },
     "postcss-dir-pseudo-class": {
@@ -11288,9 +11288,9 @@
       "integrity": "sha512-B0ey1VD1Mg8k+CLQM6V5bJ4oI+OrNpQHbft/Pfxb5IuqADGueS6BxoK3FcHEfv6Bgh3E+cistFyYK6gwXfrFNA==",
       "dev": true,
       "requires": {
-        "browserslist": "^2.4.0",
-        "postcss": "^6.0.11",
-        "postcss-selector-parser": "^2.2.3"
+        "browserslist": "2.11.3",
+        "postcss": "6.0.23",
+        "postcss-selector-parser": "2.2.3"
       }
     },
     "postcss-discard-comments": {
@@ -11299,7 +11299,7 @@
       "integrity": "sha512-Ay+rZu1Sz6g8IdzRjUgG2NafSNpp2MSMOQUb+9kkzzzP+kh07fP0yNbhtFejURnyVXSX3FYy2nVNW1QTnNjgBQ==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -11308,9 +11308,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -11319,7 +11319,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -11330,9 +11330,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -11341,7 +11341,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -11352,7 +11352,7 @@
       "integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -11361,9 +11361,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -11372,7 +11372,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -11383,9 +11383,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -11394,7 +11394,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -11405,7 +11405,7 @@
       "integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -11414,9 +11414,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -11425,7 +11425,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -11436,9 +11436,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -11447,7 +11447,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -11458,7 +11458,7 @@
       "integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -11467,9 +11467,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -11478,7 +11478,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -11489,9 +11489,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -11500,7 +11500,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -11511,8 +11511,8 @@
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.14",
-        "uniqs": "^2.0.0"
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11527,11 +11527,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -11554,10 +11554,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.5.1",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "source-map": {
@@ -11572,7 +11572,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -11583,8 +11583,8 @@
       "integrity": "sha512-zHRCKHinXtqpyrPPi3oojaf47v3eGcQHmG5zujWs1+9OWukIKi/rVEAm2KSh5y4swn66SNCZceGXcNi9GXo1cQ==",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.14",
-        "postcss-value-parser": "^3.3.0"
+        "postcss": "6.0.23",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-filter-plugins": {
@@ -11593,7 +11593,7 @@
       "integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.4"
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "ansi-styles": {
@@ -11608,11 +11608,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -11635,10 +11635,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.5.1",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "source-map": {
@@ -11653,7 +11653,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -11664,9 +11664,9 @@
       "integrity": "sha512-kLCAwdLBjF9ntnY4hYhTeDgZm8gxVzxaR9m3Wgy77CaSYwym6o14C9cz2HY5VVSgJa+ZfgtUmrn22g4HEKFxtQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.1",
-        "caniuse-lite": "^1.0.30000865",
-        "postcss": "^7.0.0"
+        "browserslist": "4.4.1",
+        "caniuse-lite": "1.0.30000888",
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "browserslist": {
@@ -11675,9 +11675,9 @@
           "integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000929",
-            "electron-to-chromium": "^1.3.103",
-            "node-releases": "^1.1.3"
+            "caniuse-lite": "1.0.30000933",
+            "electron-to-chromium": "1.3.110",
+            "node-releases": "1.1.6"
           },
           "dependencies": {
             "caniuse-lite": {
@@ -11694,9 +11694,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -11705,7 +11705,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -11722,9 +11722,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -11733,7 +11733,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -11744,7 +11744,7 @@
       "integrity": "sha1-CMzIj2BQuoLtjvLMdsDGprQfGD4=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.23"
       }
     },
     "postcss-font-weights": {
@@ -11753,9 +11753,9 @@
       "integrity": "sha1-wBAUBH9io9UdPyg8D1PxpJyhRG8=",
       "dev": true,
       "requires": {
-        "css-font-weight-names": "^0.2.1",
-        "postcss": "^6.0.1",
-        "postcss-value-parser": "^3.3.0"
+        "css-font-weight-names": "0.2.1",
+        "postcss": "6.0.23",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-html": {
@@ -11764,7 +11764,7 @@
       "integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
       "dev": true,
       "requires": {
-        "htmlparser2": "^3.10.0"
+        "htmlparser2": "3.10.0"
       }
     },
     "postcss-image-set-polyfill": {
@@ -11786,15 +11786,15 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -11817,9 +11817,9 @@
           "integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "source-map": {
@@ -11834,7 +11834,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -11845,11 +11845,11 @@
       "integrity": "sha1-TIXJewmRNsxeoCQNwd/b/eTi674=",
       "dev": true,
       "requires": {
-        "object-assign": "^4.0.1",
-        "postcss": "^6.0.1",
-        "postcss-value-parser": "^3.2.3",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
+        "object-assign": "4.1.1",
+        "postcss": "6.0.23",
+        "postcss-value-parser": "3.3.0",
+        "read-cache": "1.0.0",
+        "resolve": "1.8.1"
       }
     },
     "postcss-initial": {
@@ -11858,8 +11858,8 @@
       "integrity": "sha1-cnFfczbgu3k1HZnuZcSiU6hEG6Q=",
       "dev": true,
       "requires": {
-        "lodash.template": "^4.2.4",
-        "postcss": "^6.0.1"
+        "lodash.template": "4.4.0",
+        "postcss": "6.0.23"
       },
       "dependencies": {
         "lodash.template": {
@@ -11868,8 +11868,8 @@
           "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0",
-            "lodash.templatesettings": "^4.0.0"
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.templatesettings": "4.1.0"
           }
         },
         "lodash.templatesettings": {
@@ -11878,7 +11878,7 @@
           "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "~3.0.0"
+            "lodash._reinterpolate": "3.0.0"
           }
         }
       }
@@ -11889,7 +11889,7 @@
       "integrity": "sha512-/lWOSXSX5jlITCKFkuYU2WLFdrncZmjSVyNpHAunEgirZXLwI8RjU556e3Uz4mv0WVHnJA9d3JWb36lK9Yx99g==",
       "dev": true,
       "requires": {
-        "@babel/core": ">=7.1.0"
+        "@babel/core": "7.2.2"
       }
     },
     "postcss-less": {
@@ -11898,7 +11898,7 @@
       "integrity": "sha512-66ZBVo1JGkQ7r13M97xcHcyarWpgg21RaqIZWZXHE3XOtb5+ywK1uZWeY1DYkYRkIX/l8Hvxnx9iSKB68nFr+w==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.14"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -11907,9 +11907,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -11918,7 +11918,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -11929,9 +11929,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -11940,7 +11940,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -11951,8 +11951,8 @@
       "integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^4.0.0",
-        "import-cwd": "^2.0.0"
+        "cosmiconfig": "4.0.0",
+        "import-cwd": "2.1.0"
       },
       "dependencies": {
         "cosmiconfig": {
@@ -11961,10 +11961,10 @@
           "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
           "dev": true,
           "requires": {
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.9.0",
-            "parse-json": "^4.0.0",
-            "require-from-string": "^2.0.1"
+            "is-directory": "0.3.1",
+            "js-yaml": "3.12.1",
+            "parse-json": "4.0.0",
+            "require-from-string": "2.0.2"
           }
         },
         "parse-json": {
@@ -11973,19 +11973,19 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.2",
+            "json-parse-better-errors": "1.0.2"
           }
         }
       }
     },
     "postcss-logical": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/postcss-logical/-/postcss-logical-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-1.1.1.tgz",
       "integrity": "sha512-ZJgyLJlp3uPKae9+6sJKFjD06UZzb/m3M1LPeHsaBMvvyatcNWwCfOZVIq00fJdxUqa9QeuQO6RZElKmRdWMEg==",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.20"
+        "postcss": "6.0.23"
       }
     },
     "postcss-markdown": {
@@ -11994,8 +11994,8 @@
       "integrity": "sha512-rl7fs1r/LNSB2bWRhyZ+lM/0bwKv9fhl38/06gF6mKMo/NPnp55+K1dSTosSVjFZc0e1ppBlu+WT91ba0PMBfQ==",
       "dev": true,
       "requires": {
-        "remark": "^10.0.1",
-        "unist-util-find-all-after": "^1.0.2"
+        "remark": "10.0.1",
+        "unist-util-find-all-after": "1.0.2"
       }
     },
     "postcss-media-fn": {
@@ -12004,8 +12004,8 @@
       "integrity": "sha512-qbkS/b0+MdI2aIS/JDvCCTaYeLZ5w1HDn7Y+Q8fr30HRZx9e1SzV01t54GIyLJVTY5OO0pyxXybCI6ji3bcJ2w==",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1",
-        "postcss-value-parser": "^3.3.0"
+        "postcss": "6.0.23",
+        "postcss-value-parser": "3.3.0"
       }
     },
     "postcss-media-minmax": {
@@ -12014,7 +12014,7 @@
       "integrity": "sha1-Z1JWA3pD70C8Twdgv9BtTcadSNI=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.23"
       }
     },
     "postcss-media-query-parser": {
@@ -12029,9 +12029,9 @@
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.10",
-        "postcss-value-parser": "^3.1.1"
+        "has": "1.0.3",
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -12046,11 +12046,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12073,10 +12073,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.5.1",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "source-map": {
@@ -12091,7 +12091,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -12103,9 +12103,9 @@
       "dev": true,
       "requires": {
         "css-color-names": "0.0.4",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "stylehacks": "^4.0.0"
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0",
+        "stylehacks": "4.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -12114,9 +12114,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12125,7 +12125,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -12136,9 +12136,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -12147,7 +12147,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12158,12 +12158,12 @@
       "integrity": "sha512-UiuXwCCJtQy9tAIxsnurfF0mrNHKc4NnNx6NxqmzNNjXpQwLSukUxELHTRF0Rg1pAmcoKLih8PwvZbiordchag==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
-        "caniuse-api": "^3.0.0",
-        "cssnano-util-same-parent": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0",
-        "vendors": "^1.0.0"
+        "browserslist": "4.4.1",
+        "caniuse-api": "3.0.0",
+        "cssnano-util-same-parent": "4.0.1",
+        "postcss": "7.0.14",
+        "postcss-selector-parser": "3.1.1",
+        "vendors": "1.0.2"
       },
       "dependencies": {
         "browserslist": {
@@ -12172,9 +12172,9 @@
           "integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000929",
-            "electron-to-chromium": "^1.3.103",
-            "node-releases": "^1.1.3"
+            "caniuse-lite": "1.0.30000933",
+            "electron-to-chromium": "1.3.110",
+            "node-releases": "1.1.6"
           }
         },
         "caniuse-lite": {
@@ -12189,9 +12189,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12200,7 +12200,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -12217,9 +12217,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "postcss-selector-parser": {
@@ -12228,9 +12228,9 @@
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
-            "dot-prop": "^4.1.1",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "dot-prop": "4.2.0",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         },
         "supports-color": {
@@ -12239,7 +12239,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12256,8 +12256,8 @@
       "integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -12266,9 +12266,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12277,7 +12277,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -12288,9 +12288,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -12299,7 +12299,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12310,10 +12310,10 @@
       "integrity": "sha512-pySEW3E6Ly5mHm18rekbWiAjVi/Wj8KKt2vwSfVFAWdW6wOIekgqxKxLU7vJfb107o3FDNPkaYFCxGAJBFyogA==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "is-color-stop": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-arguments": "4.0.0",
+        "is-color-stop": "1.1.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -12322,9 +12322,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12333,7 +12333,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -12344,9 +12344,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -12355,7 +12355,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12366,12 +12366,12 @@
       "integrity": "sha512-h4W0FEMEzBLxpxIVelRtMheskOKKp52ND6rJv+nBS33G1twu2tCyurYj/YtgU76+UDCvWeNs0hs8HFAWE2OUFg==",
       "dev": true,
       "requires": {
-        "alphanum-sort": "^1.0.0",
-        "browserslist": "^4.0.0",
-        "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "browserslist": "4.4.1",
+        "cssnano-util-get-arguments": "4.0.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0",
+        "uniqs": "2.0.0"
       },
       "dependencies": {
         "browserslist": {
@@ -12380,9 +12380,9 @@
           "integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000929",
-            "electron-to-chromium": "^1.3.103",
-            "node-releases": "^1.1.3"
+            "caniuse-lite": "1.0.30000933",
+            "electron-to-chromium": "1.3.110",
+            "node-releases": "1.1.6"
           }
         },
         "caniuse-lite": {
@@ -12397,9 +12397,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12408,7 +12408,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -12425,9 +12425,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -12436,7 +12436,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12447,10 +12447,10 @@
       "integrity": "sha512-8+plQkomve3G+CodLCgbhAKrb5lekAnLYuL1d7Nz+/7RANpBEVdgBkPNwljfSKvZ9xkkZTZITd04KP+zeJTJqg==",
       "dev": true,
       "requires": {
-        "alphanum-sort": "^1.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0"
+        "alphanum-sort": "1.0.2",
+        "has": "1.0.3",
+        "postcss": "7.0.14",
+        "postcss-selector-parser": "3.1.1"
       },
       "dependencies": {
         "chalk": {
@@ -12459,9 +12459,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12470,7 +12470,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -12481,9 +12481,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "postcss-selector-parser": {
@@ -12492,9 +12492,9 @@
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
-            "dot-prop": "^4.1.1",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "dot-prop": "4.2.0",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         },
         "supports-color": {
@@ -12503,7 +12503,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12514,7 +12514,7 @@
       "integrity": "sha512-IkyWXICwagCnlaviRexi7qOdwPw3+xVVjgFfGsxmztvRVaNxAlrypOIKqDE5mxY+BVxnId1rnUKBRQoNE2VDaA==",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.11"
+        "postcss": "6.0.23"
       }
     },
     "postcss-normalize-charset": {
@@ -12523,7 +12523,7 @@
       "integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -12532,9 +12532,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12543,7 +12543,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -12554,9 +12554,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -12565,7 +12565,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12576,9 +12576,9 @@
       "integrity": "sha512-R5mC4vaDdvsrku96yXP7zak+O3Mm9Y8IslUobk7IMP+u/g+lXvcN4jngmHY5zeJnrQvE13dfAg5ViU05ZFDwdg==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-match": "4.0.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -12587,9 +12587,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12598,7 +12598,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -12609,9 +12609,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -12620,7 +12620,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12631,10 +12631,10 @@
       "integrity": "sha512-GNoOaLRBM0gvH+ZRb2vKCIujzz4aclli64MBwDuYGU2EY53LwiP7MxOZGE46UGtotrSnmarPPZ69l2S/uxdaWA==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-arguments": "4.0.0",
+        "has": "1.0.3",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -12643,9 +12643,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12654,7 +12654,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -12665,9 +12665,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -12676,7 +12676,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12687,10 +12687,10 @@
       "integrity": "sha512-fFHPGIjBUyUiswY2rd9rsFcC0t3oRta4wxE1h3lpwfQZwFeFjXFSiDtdJ7APCmHQOnUZnqYBADNRPKPwFAONgA==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-arguments": "4.0.0",
+        "cssnano-util-get-match": "4.0.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -12699,9 +12699,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12710,7 +12710,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -12721,9 +12721,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -12732,7 +12732,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12743,9 +12743,9 @@
       "integrity": "sha512-IJoexFTkAvAq5UZVxWXAGE0yLoNN/012v7TQh5nDo6imZJl2Fwgbhy3J2qnIoaDBrtUP0H7JrXlX1jjn2YcvCQ==",
       "dev": true,
       "requires": {
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "has": "1.0.3",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -12754,9 +12754,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12765,7 +12765,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -12776,9 +12776,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -12787,7 +12787,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12798,9 +12798,9 @@
       "integrity": "sha512-1nOtk7ze36+63ONWD8RCaRDYsnzorrj+Q6fxkQV+mlY5+471Qx9kspqv0O/qQNMeApg8KNrRf496zHwJ3tBZ7w==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-match": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-match": "4.0.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -12809,9 +12809,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12820,7 +12820,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -12831,9 +12831,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -12842,7 +12842,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12853,9 +12853,9 @@
       "integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "browserslist": "4.4.1",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "browserslist": {
@@ -12864,9 +12864,9 @@
           "integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000929",
-            "electron-to-chromium": "^1.3.103",
-            "node-releases": "^1.1.3"
+            "caniuse-lite": "1.0.30000933",
+            "electron-to-chromium": "1.3.110",
+            "node-releases": "1.1.6"
           }
         },
         "caniuse-lite": {
@@ -12881,9 +12881,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12892,7 +12892,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -12909,9 +12909,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -12920,7 +12920,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12931,10 +12931,10 @@
       "integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
       "dev": true,
       "requires": {
-        "is-absolute-url": "^2.0.0",
-        "normalize-url": "^3.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "is-absolute-url": "2.1.0",
+        "normalize-url": "3.3.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -12943,9 +12943,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -12954,7 +12954,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -12965,9 +12965,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -12976,7 +12976,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -12987,8 +12987,8 @@
       "integrity": "sha512-U8MBODMB2L+nStzOk6VvWWjZgi5kQNShCyjRhMT3s+W9Jw93yIjOnrEkKYD3Ul7ChWbEcjDWmXq0qOL9MIAnAw==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -12997,9 +12997,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13008,7 +13008,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -13019,9 +13019,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -13030,7 +13030,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13041,9 +13041,9 @@
       "integrity": "sha512-PeJiLgJWPzkVF8JuKSBcylaU+hDJ/TX3zqAMIjlghgn1JBi6QwQaDZoDIlqWRcCAI8SxKrt3FCPSRmOgKRB97Q==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-arguments": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-arguments": "4.0.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -13052,9 +13052,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13063,7 +13063,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -13074,9 +13074,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -13085,7 +13085,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13096,7 +13096,7 @@
       "integrity": "sha1-CkBSu05XTlfwuZMZ7GaHv8bVKr4=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.23"
       }
     },
     "postcss-partial-import": {
@@ -13105,8 +13105,8 @@
       "integrity": "sha1-9sPnjnu+2k2dq5bTYDZ7kLNT+aQ=",
       "dev": true,
       "requires": {
-        "glob": "^7.1.1",
-        "postcss-import": "^10.0.0"
+        "glob": "7.1.3",
+        "postcss-import": "10.0.0"
       }
     },
     "postcss-pseudo-class-any-link": {
@@ -13115,8 +13115,8 @@
       "integrity": "sha1-kVKgYT00UHIFE+iJKFS65C0O5o4=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1",
-        "postcss-selector-parser": "^2.2.3"
+        "postcss": "6.0.23",
+        "postcss-selector-parser": "2.2.3"
       }
     },
     "postcss-reduce-idents": {
@@ -13125,8 +13125,8 @@
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.4",
-        "postcss-value-parser": "^3.0.2"
+        "postcss": "5.2.18",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13141,11 +13141,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13168,10 +13168,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.5.1",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "source-map": {
@@ -13186,7 +13186,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -13197,10 +13197,10 @@
       "integrity": "sha512-epUiC39NonKUKG+P3eAOKKZtm5OtAtQJL7Ye0CBN1f+UQTHzqotudp+hki7zxXm7tT0ZAKDMBj1uihpPjP25ug==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
-        "caniuse-api": "^3.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0"
+        "browserslist": "4.4.1",
+        "caniuse-api": "3.0.0",
+        "has": "1.0.3",
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "browserslist": {
@@ -13209,9 +13209,9 @@
           "integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000929",
-            "electron-to-chromium": "^1.3.103",
-            "node-releases": "^1.1.3"
+            "caniuse-lite": "1.0.30000933",
+            "electron-to-chromium": "1.3.110",
+            "node-releases": "1.1.6"
           }
         },
         "caniuse-lite": {
@@ -13226,9 +13226,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13237,7 +13237,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -13254,9 +13254,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -13265,7 +13265,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13276,10 +13276,10 @@
       "integrity": "sha512-sZVr3QlGs0pjh6JAIe6DzWvBaqYw05V1t3d9Tp+VnFRT5j+rsqoWsysh/iSD7YNsULjq9IAylCznIwVd5oU/zA==",
       "dev": true,
       "requires": {
-        "cssnano-util-get-match": "^4.0.0",
-        "has": "^1.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0"
+        "cssnano-util-get-match": "4.0.0",
+        "has": "1.0.3",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -13288,9 +13288,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13299,7 +13299,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -13310,9 +13310,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -13321,7 +13321,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13332,7 +13332,7 @@
       "integrity": "sha1-eU22+qVPjbEAhUOSqTr0V2i04ls=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.23"
       }
     },
     "postcss-reporter": {
@@ -13341,10 +13341,10 @@
       "integrity": "sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
-        "lodash": "^4.17.11",
-        "log-symbols": "^2.2.0",
-        "postcss": "^7.0.7"
+        "chalk": "2.4.1",
+        "lodash": "4.17.11",
+        "log-symbols": "2.2.0",
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "postcss": {
@@ -13353,9 +13353,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           },
           "dependencies": {
             "chalk": {
@@ -13364,9 +13364,9 @@
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.5.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -13375,7 +13375,7 @@
                   "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                   "dev": true,
                   "requires": {
-                    "has-flag": "^3.0.0"
+                    "has-flag": "3.0.0"
                   }
                 }
               }
@@ -13388,7 +13388,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13405,7 +13405,7 @@
       "integrity": "sha512-xZsFA3uX8MO3yAda03QrG3/Eg1LN3EPfjjf07vke/46HERLZyHrTsQ9E1r1w1W//fWEhtYNndo2hQplN2cVpCQ==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -13414,9 +13414,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13425,7 +13425,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -13436,9 +13436,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -13447,7 +13447,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13458,8 +13458,8 @@
       "integrity": "sha512-B5z2Kob4xBxFjcufFnhQ2HqJQ2y/Zs/ic5EZbCywCkxKd756Q40cIQ/veRDwSrw1BF6+4wUgmpm0sBASqVi65A==",
       "dev": true,
       "requires": {
-        "gonzales-pe": "^4.2.3",
-        "postcss": "^7.0.1"
+        "gonzales-pe": "4.2.3",
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -13468,9 +13468,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13479,7 +13479,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -13490,9 +13490,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -13501,7 +13501,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13512,7 +13512,7 @@
       "integrity": "sha512-um9zdGKaDZirMm+kZFKKVsnKPF7zF7qBAtIfTSnZXD1jZ0JNZIxdB6TxQOjCnlSzLRInVl2v3YdBh/M881C4ug==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.0"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -13521,9 +13521,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13532,7 +13532,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -13543,9 +13543,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -13554,7 +13554,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13565,8 +13565,8 @@
       "integrity": "sha1-5WNAEeE5UIgYYbvdWMLQER/8lqs=",
       "dev": true,
       "requires": {
-        "balanced-match": "^0.4.2",
-        "postcss": "^6.0.1"
+        "balanced-match": "0.4.2",
+        "postcss": "6.0.23"
       },
       "dependencies": {
         "balanced-match": {
@@ -13583,8 +13583,8 @@
       "integrity": "sha1-Lk2y8JZTNsAefOx9tsYN/3ZzNdk=",
       "dev": true,
       "requires": {
-        "balanced-match": "^0.4.2",
-        "postcss": "^6.0.1"
+        "balanced-match": "0.4.2",
+        "postcss": "6.0.23"
       },
       "dependencies": {
         "balanced-match": {
@@ -13601,9 +13601,9 @@
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
       "dev": true,
       "requires": {
-        "flatten": "^1.0.2",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
       }
     },
     "postcss-short": {
@@ -13612,16 +13612,16 @@
       "integrity": "sha512-RQ7kVYQTK6Pf1jMN3RfYwQT7Y2zDxTKCMQcc+Gmo8TCrMeC21pbTJRily3SEOHl+GbYPD6A6TzXAynhs5n/OlQ==",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1",
-        "postcss-font-weights": "^4.0.0",
-        "postcss-overflow": "^1.1.5",
-        "postcss-short-border": "^3.0.0",
-        "postcss-short-border-radius": "^2.0.0",
-        "postcss-short-color": "^3.0.0",
-        "postcss-short-font-size": "^4.0.0",
-        "postcss-short-position": "^3.0.0",
-        "postcss-short-size": "^3.0.0",
-        "postcss-short-spacing": "^3.0.0"
+        "postcss": "6.0.23",
+        "postcss-font-weights": "4.0.0",
+        "postcss-overflow": "1.1.5",
+        "postcss-short-border": "3.0.0",
+        "postcss-short-border-radius": "2.0.0",
+        "postcss-short-color": "3.0.0",
+        "postcss-short-font-size": "4.0.0",
+        "postcss-short-position": "3.0.0",
+        "postcss-short-size": "3.0.0",
+        "postcss-short-spacing": "3.0.0"
       }
     },
     "postcss-short-border": {
@@ -13630,7 +13630,7 @@
       "integrity": "sha1-5WN5xKL1Mn2B22Gs1CvGAl38udk=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.23"
       }
     },
     "postcss-short-border-radius": {
@@ -13639,7 +13639,7 @@
       "integrity": "sha1-qHsdYKxDMiKWOUXZDit6WzvCRFM=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.23"
       }
     },
     "postcss-short-color": {
@@ -13648,7 +13648,7 @@
       "integrity": "sha1-h06a8zAc9fVBPXvSNcrx3AEFrDg=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.23"
       }
     },
     "postcss-short-font-size": {
@@ -13657,7 +13657,7 @@
       "integrity": "sha1-dQpEEad26d7s3JC56NgiJu95zuk=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.23"
       }
     },
     "postcss-short-position": {
@@ -13666,7 +13666,7 @@
       "integrity": "sha1-GHQQWkyMdo/le7uKtfBIpUMSk9Q=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.23"
       }
     },
     "postcss-short-size": {
@@ -13675,7 +13675,7 @@
       "integrity": "sha1-CQXhHHwU1CVRJgQHiU9XRmwQL7w=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.23"
       }
     },
     "postcss-short-spacing": {
@@ -13684,7 +13684,7 @@
       "integrity": "sha1-NgxeSW/KElCu6sWYjYLnxAk1LKA=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1"
+        "postcss": "6.0.23"
       }
     },
     "postcss-sorting": {
@@ -13693,8 +13693,8 @@
       "integrity": "sha512-YNRq7ChWFsLsns78zutLBWp6kvfZr/3YYf9q54P/fBpIHhf8gwbKvr5XHAt2l69SS08lfGtB8gG8m/62gsuTgw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.4",
-        "postcss": "^7.0.0"
+        "lodash": "4.17.11",
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -13703,9 +13703,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13714,7 +13714,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -13725,9 +13725,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -13736,7 +13736,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13747,10 +13747,10 @@
       "integrity": "sha512-FnUXPGegPT8XvrexePo8UbcGQu2tppbcekZ+V/50mRIzb3BDxwaqKeQ39nZVgGcXcTInH1s7+dt/sl10QrY0Dw==",
       "dev": true,
       "requires": {
-        "postcss": "6.x",
-        "postcss-value-parser": "3.x",
-        "svgo": "1.x",
-        "xmldoc": "1.x"
+        "postcss": "6.0.23",
+        "postcss-value-parser": "3.3.0",
+        "svgo": "1.1.1",
+        "xmldoc": "1.1.2"
       },
       "dependencies": {
         "coa": {
@@ -13759,7 +13759,7 @@
           "integrity": "sha512-5wfTTO8E2/ja4jFSxePXlG5nRu5bBtL/r1HCIpJW/lzT6yDtKl0u0Z4o/Vpz32IpKmBn7HerheEZQgA9N2DarQ==",
           "dev": true,
           "requires": {
-            "q": "^1.1.2"
+            "q": "1.5.1"
           }
         },
         "csso": {
@@ -13777,8 +13777,8 @@
               "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
               "dev": true,
               "requires": {
-                "mdn-data": "~1.1.0",
-                "source-map": "^0.5.3"
+                "mdn-data": "1.1.4",
+                "source-map": "0.5.7"
               }
             }
           }
@@ -13795,8 +13795,8 @@
           "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "1.0.10",
+            "esprima": "4.0.1"
           }
         },
         "source-map": {
@@ -13811,20 +13811,20 @@
           "integrity": "sha512-GBkJbnTuFpM4jFbiERHDWhZc/S/kpHToqmZag3aEBjPYK44JAN2QBjvrGIxLOoCyMZjuFQIfTO2eJd8uwLY/9g==",
           "dev": true,
           "requires": {
-            "coa": "~2.0.1",
-            "colors": "~1.1.2",
-            "css-select": "^2.0.0",
-            "css-select-base-adapter": "~0.1.0",
+            "coa": "2.0.1",
+            "colors": "1.1.2",
+            "css-select": "2.0.0",
+            "css-select-base-adapter": "0.1.0",
             "css-tree": "1.0.0-alpha.28",
-            "css-url-regex": "^1.1.0",
-            "csso": "^3.5.0",
-            "js-yaml": "^3.12.0",
-            "mkdirp": "~0.5.1",
-            "object.values": "^1.0.4",
-            "sax": "~1.2.4",
-            "stable": "~0.1.6",
-            "unquote": "~1.1.1",
-            "util.promisify": "~1.0.0"
+            "css-url-regex": "1.1.0",
+            "csso": "3.5.1",
+            "js-yaml": "3.12.0",
+            "mkdirp": "0.5.1",
+            "object.values": "1.0.4",
+            "sax": "1.2.4",
+            "stable": "0.1.8",
+            "unquote": "1.1.1",
+            "util.promisify": "1.0.0"
           }
         }
       }
@@ -13835,10 +13835,10 @@
       "integrity": "sha512-YD5uIk5NDRySy0hcI+ZJHwqemv2WiqqzDgtvgMzO8EGSkK5aONyX8HMVFRFJSdO8wUWTuisUFn/d7yRRbBr5Qw==",
       "dev": true,
       "requires": {
-        "is-svg": "^3.0.0",
-        "postcss": "^7.0.0",
-        "postcss-value-parser": "^3.0.0",
-        "svgo": "^1.0.0"
+        "is-svg": "3.0.0",
+        "postcss": "7.0.14",
+        "postcss-value-parser": "3.3.0",
+        "svgo": "1.1.1"
       },
       "dependencies": {
         "chalk": {
@@ -13847,9 +13847,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13858,7 +13858,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -13869,9 +13869,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -13880,7 +13880,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13897,9 +13897,9 @@
       "integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
       "dev": true,
       "requires": {
-        "alphanum-sort": "^1.0.0",
-        "postcss": "^7.0.0",
-        "uniqs": "^2.0.0"
+        "alphanum-sort": "1.0.2",
+        "postcss": "7.0.14",
+        "uniqs": "2.0.0"
       },
       "dependencies": {
         "chalk": {
@@ -13908,9 +13908,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -13919,7 +13919,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -13930,9 +13930,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -13941,7 +13941,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -13954,13 +13954,13 @@
     },
     "postcss-values-parser": {
       "version": "1.5.0",
-      "resolved": "http://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-1.5.0.tgz",
       "integrity": "sha512-3M3p+2gMp0AH3da530TlX8kiO1nxdTnc3C6vr8dMxRLIlh8UYkz0/wcwptSXjhtx2Fr0TySI7a+BHDQ8NL7LaQ==",
       "dev": true,
       "requires": {
-        "flatten": "^1.0.2",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
       }
     },
     "postcss-zindex": {
@@ -13969,9 +13969,9 @@
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1",
-        "postcss": "^5.0.4",
-        "uniqs": "^2.0.0"
+        "has": "1.0.3",
+        "postcss": "5.2.18",
+        "uniqs": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -13986,11 +13986,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -14013,10 +14013,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
+            "chalk": "1.1.3",
+            "js-base64": "2.5.1",
+            "source-map": "0.5.7",
+            "supports-color": "3.2.3"
           }
         },
         "source-map": {
@@ -14031,7 +14031,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "1.0.0"
           }
         }
       }
@@ -14042,9 +14042,9 @@
       "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "spawn-sync": "^1.0.15",
-        "which": "1.2.x"
+        "cross-spawn": "5.1.0",
+        "spawn-sync": "1.0.15",
+        "which": "1.2.14"
       },
       "dependencies": {
         "which": {
@@ -14053,7 +14053,7 @@
           "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         }
       }
@@ -14112,8 +14112,8 @@
       "integrity": "sha1-+sY6Cz0R3qy7CWmrzJOyFLzhntU=",
       "dev": true,
       "requires": {
-        "speedometer": "~1.0.0",
-        "through2": "~2.0.3"
+        "speedometer": "1.0.0",
+        "through2": "2.0.3"
       }
     },
     "pseudomap": {
@@ -14134,8 +14134,8 @@
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "pumpify": {
@@ -14144,9 +14144,9 @@
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
+        "duplexify": "3.6.1",
+        "inherits": "2.0.3",
+        "pump": "2.0.1"
       }
     },
     "punycode": {
@@ -14173,8 +14173,8 @@
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "dev": true,
       "requires": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
       }
     },
     "quick-lru": {
@@ -14189,9 +14189,9 @@
       "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -14232,15 +14232,15 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -14252,7 +14252,7 @@
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "requires": {
-        "mute-stream": "~0.0.4"
+        "mute-stream": "0.0.7"
       }
     },
     "read-cache": {
@@ -14261,7 +14261,7 @@
       "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
       "dev": true,
       "requires": {
-        "pify": "^2.3.0"
+        "pify": "2.3.0"
       }
     },
     "read-pkg": {
@@ -14270,9 +14270,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -14281,23 +14281,23 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       }
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       },
       "dependencies": {
         "isarray": {
@@ -14314,9 +14314,9 @@
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
+        "graceful-fs": "4.1.11",
+        "micromatch": "3.1.10",
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "arr-diff": {
@@ -14337,16 +14337,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -14355,7 +14355,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -14366,13 +14366,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -14381,7 +14381,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -14390,7 +14390,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -14399,7 +14399,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -14408,7 +14408,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -14419,7 +14419,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -14428,7 +14428,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -14439,9 +14439,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -14458,14 +14458,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -14474,7 +14474,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -14483,7 +14483,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -14494,10 +14494,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -14506,7 +14506,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -14517,7 +14517,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -14526,7 +14526,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -14535,9 +14535,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-number": {
@@ -14546,7 +14546,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -14555,7 +14555,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -14578,19 +14578,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         }
       }
@@ -14601,7 +14601,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.8.1"
       }
     },
     "redent": {
@@ -14610,8 +14610,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       }
     },
     "reduce-css-calc": {
@@ -14620,9 +14620,9 @@
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
       "requires": {
-        "balanced-match": "^0.4.2",
-        "math-expression-evaluator": "^1.2.14",
-        "reduce-function-call": "^1.0.1"
+        "balanced-match": "0.4.2",
+        "math-expression-evaluator": "1.2.17",
+        "reduce-function-call": "1.0.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -14639,7 +14639,7 @@
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "dev": true,
       "requires": {
-        "balanced-match": "^0.4.2"
+        "balanced-match": "0.4.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -14668,9 +14668,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.18.0",
-        "babel-types": "^6.19.0",
-        "private": "^0.1.6"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
@@ -14679,7 +14679,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -14688,8 +14688,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexpp": {
@@ -14704,9 +14704,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
+        "regenerate": "1.4.0",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
       }
     },
     "registry-auth-token": {
@@ -14715,8 +14715,8 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "1.2.8",
+        "safe-buffer": "5.1.2"
       }
     },
     "registry-url": {
@@ -14725,7 +14725,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "1.2.8"
       }
     },
     "regjsgen": {
@@ -14740,7 +14740,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -14757,9 +14757,9 @@
       "integrity": "sha512-E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==",
       "dev": true,
       "requires": {
-        "remark-parse": "^6.0.0",
-        "remark-stringify": "^6.0.0",
-        "unified": "^7.0.0"
+        "remark-parse": "6.0.3",
+        "remark-stringify": "6.0.4",
+        "unified": "7.1.0"
       }
     },
     "remark-parse": {
@@ -14768,21 +14768,21 @@
       "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
       "dev": true,
       "requires": {
-        "collapse-white-space": "^1.0.2",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.1.0",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
+        "collapse-white-space": "1.0.4",
+        "is-alphabetical": "1.0.2",
+        "is-decimal": "1.0.2",
+        "is-whitespace-character": "1.0.2",
+        "is-word-character": "1.0.2",
+        "markdown-escapes": "1.0.2",
+        "parse-entities": "1.2.0",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.1",
         "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
-        "xtend": "^4.0.1"
+        "trim-trailing-lines": "1.1.1",
+        "unherit": "1.1.1",
+        "unist-util-remove-position": "1.1.2",
+        "vfile-location": "2.0.4",
+        "xtend": "4.0.1"
       }
     },
     "remark-stringify": {
@@ -14791,20 +14791,20 @@
       "integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
       "dev": true,
       "requires": {
-        "ccount": "^1.0.0",
-        "is-alphanumeric": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "longest-streak": "^2.0.1",
-        "markdown-escapes": "^1.0.0",
-        "markdown-table": "^1.1.0",
-        "mdast-util-compact": "^1.0.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "stringify-entities": "^1.0.1",
-        "unherit": "^1.0.4",
-        "xtend": "^4.0.1"
+        "ccount": "1.0.3",
+        "is-alphanumeric": "1.0.0",
+        "is-decimal": "1.0.2",
+        "is-whitespace-character": "1.0.2",
+        "longest-streak": "2.0.2",
+        "markdown-escapes": "1.0.2",
+        "markdown-table": "1.1.2",
+        "mdast-util-compact": "1.0.2",
+        "parse-entities": "1.2.0",
+        "repeat-string": "1.6.1",
+        "state-toggle": "1.0.1",
+        "stringify-entities": "1.3.2",
+        "unherit": "1.1.1",
+        "xtend": "4.0.1"
       }
     },
     "remove-bom-buffer": {
@@ -14813,8 +14813,8 @@
       "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5",
-        "is-utf8": "^0.2.1"
+        "is-buffer": "1.1.6",
+        "is-utf8": "0.2.1"
       }
     },
     "remove-bom-stream": {
@@ -14823,9 +14823,9 @@
       "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
       "dev": true,
       "requires": {
-        "remove-bom-buffer": "^3.0.0",
-        "safe-buffer": "^5.1.0",
-        "through2": "^2.0.3"
+        "remove-bom-buffer": "3.0.0",
+        "safe-buffer": "5.1.2",
+        "through2": "2.0.3"
       }
     },
     "remove-markdown": {
@@ -14864,7 +14864,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "replace-ext": {
@@ -14879,9 +14879,9 @@
       "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1",
-        "is-absolute": "^1.0.0",
-        "remove-trailing-separator": "^1.1.0"
+        "homedir-polyfill": "1.0.1",
+        "is-absolute": "1.0.0",
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "request": {
@@ -14890,26 +14890,26 @@
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.7",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.1.0",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.20",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       },
       "dependencies": {
         "qs": {
@@ -14956,7 +14956,7 @@
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-dir": {
@@ -14965,8 +14965,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       }
     },
     "resolve-from": {
@@ -14981,7 +14981,7 @@
       "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
       "dev": true,
       "requires": {
-        "value-or-function": "^3.0.0"
+        "value-or-function": "3.0.0"
       }
     },
     "resolve-url": {
@@ -14996,8 +14996,8 @@
       "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
       "dev": true,
       "requires": {
-        "debug": "^2.2.0",
-        "minimatch": "^3.0.2"
+        "debug": "2.6.9",
+        "minimatch": "3.0.4"
       }
     },
     "restore-cursor": {
@@ -15006,8 +15006,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "ret": {
@@ -15040,7 +15040,7 @@
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3"
+        "glob": "7.1.3"
       }
     },
     "rollup": {
@@ -15050,8 +15050,8 @@
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "*",
-        "acorn": "^6.0.5"
+        "@types/node": "10.12.20",
+        "acorn": "6.0.6"
       },
       "dependencies": {
         "acorn": {
@@ -15068,20 +15068,20 @@
       "integrity": "sha512-bVe2y0z/V5Ax1qU8NX/0idmzIwJPdUGu8Xx3vXH73h0yGjxfv2gkFI82MBVg49SlsFlLTBadBHb67zy4TWM3hA==",
       "dev": true,
       "requires": {
-        "rollup-pluginutils": "^1.5.0"
+        "rollup-pluginutils": "1.5.2"
       }
     },
     "rollup-plugin-commonjs": {
       "version": "8.4.1",
-      "resolved": "http://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.4.1.tgz",
       "integrity": "sha512-mg+WuD+jlwoo8bJtW3Mvx7Tz6TsIdMsdhuvCnDMoyjh0oxsVgsjB/N0X984RJCWwc5IIiqNVJhXeeITcc73++A==",
       "dev": true,
       "requires": {
-        "acorn": "^5.2.1",
-        "estree-walker": "^0.5.0",
-        "magic-string": "^0.22.4",
-        "resolve": "^1.4.0",
-        "rollup-pluginutils": "^2.0.1"
+        "acorn": "5.7.3",
+        "estree-walker": "0.5.2",
+        "magic-string": "0.22.5",
+        "resolve": "1.8.1",
+        "rollup-pluginutils": "2.3.3"
       },
       "dependencies": {
         "estree-walker": {
@@ -15096,8 +15096,8 @@
           "integrity": "sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==",
           "dev": true,
           "requires": {
-            "estree-walker": "^0.5.2",
-            "micromatch": "^2.3.11"
+            "estree-walker": "0.5.2",
+            "micromatch": "2.3.11"
           }
         }
       }
@@ -15108,7 +15108,7 @@
       "integrity": "sha512-BlYk5VspvGpjz7lAwArVzBXR60JK+4EKtPkCHouAWg39obk9S61hZYJDBfMK+oitPdoe11i69TlxKlMQNFC/Uw==",
       "dev": true,
       "requires": {
-        "rollup-pluginutils": "^2.3.1"
+        "rollup-pluginutils": "2.3.3"
       },
       "dependencies": {
         "estree-walker": {
@@ -15123,8 +15123,8 @@
           "integrity": "sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==",
           "dev": true,
           "requires": {
-            "estree-walker": "^0.5.2",
-            "micromatch": "^2.3.11"
+            "estree-walker": "0.5.2",
+            "micromatch": "2.3.11"
           }
         }
       }
@@ -15135,9 +15135,9 @@
       "integrity": "sha512-PJcd85dxfSBWih84ozRtBkB731OjXk0KnzN0oGp7WOWcarAFkVa71cV5hTJg2qpVsV2U8EUwrzHP3tvy9vS3qg==",
       "dev": true,
       "requires": {
-        "builtin-modules": "^2.0.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.1.6"
+        "builtin-modules": "2.0.0",
+        "is-module": "1.0.0",
+        "resolve": "1.8.1"
       },
       "dependencies": {
         "builtin-modules": {
@@ -15154,20 +15154,20 @@
       "integrity": "sha512-qwz2Tryspn5QGtPUowq5oumKSxANKdrnfz7C0jm4lKxvRDsNe/hSGsB9FntUul7UeC4TsZEWKErVgE1qWSO0gw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "jest-worker": "^24.0.0",
-        "serialize-javascript": "^1.6.1",
-        "uglify-js": "^3.4.9"
+        "@babel/code-frame": "7.0.0",
+        "jest-worker": "24.0.0",
+        "serialize-javascript": "1.6.1",
+        "uglify-js": "3.4.9"
       }
     },
     "rollup-pluginutils": {
       "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
       "integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
       "dev": true,
       "requires": {
-        "estree-walker": "^0.2.1",
-        "minimatch": "^3.0.2"
+        "estree-walker": "0.2.1",
+        "minimatch": "3.0.4"
       }
     },
     "rollup-stream": {
@@ -15176,7 +15176,7 @@
       "integrity": "sha512-iQ159xbWSOPc7ey8tjEYf7pCaQwBz3ov37KNCeDewqh6Qj1gntAgZSmmEJIPs2niXMDNqVZ3rnTFXBXhZ+sYSg==",
       "dev": true,
       "requires": {
-        "rollup": "^0.49.2"
+        "rollup": "0.49.3"
       },
       "dependencies": {
         "rollup": {
@@ -15193,7 +15193,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "rx": {
@@ -15208,7 +15208,7 @@
       "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.3"
       }
     },
     "safe-buffer": {
@@ -15223,7 +15223,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -15250,7 +15250,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "^5.0.3"
+        "semver": "5.5.1"
       }
     },
     "semver-greatest-satisfied-range": {
@@ -15259,7 +15259,7 @@
       "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
       "dev": true,
       "requires": {
-        "sver-compat": "^1.5.0"
+        "sver-compat": "1.5.0"
       }
     },
     "send": {
@@ -15269,18 +15269,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
+        "http-errors": "1.6.3",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "statuses": {
@@ -15303,13 +15303,13 @@
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "1.3.5",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.6.2",
-        "mime-types": "~2.1.17",
-        "parseurl": "~1.3.2"
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.3",
+        "mime-types": "2.1.20",
+        "parseurl": "1.3.2"
       }
     },
     "serve-static": {
@@ -15318,9 +15318,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
         "send": "0.16.2"
       }
     },
@@ -15342,10 +15342,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -15354,7 +15354,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -15371,7 +15371,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -15398,7 +15398,7 @@
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.3.1"
+        "is-arrayish": "0.3.2"
       },
       "dependencies": {
         "is-arrayish": {
@@ -15421,9 +15421,9 @@
       "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "astral-regex": "^1.0.0",
-        "is-fullwidth-code-point": "^2.0.0"
+        "ansi-styles": "3.2.1",
+        "astral-regex": "1.0.0",
+        "is-fullwidth-code-point": "2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -15440,14 +15440,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -15456,7 +15456,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -15465,7 +15465,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "source-map": {
@@ -15482,9 +15482,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -15493,7 +15493,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -15502,7 +15502,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -15511,7 +15511,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -15520,9 +15520,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "isobject": {
@@ -15545,7 +15545,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       }
     },
     "socket.io": {
@@ -15554,12 +15554,12 @@
       "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
       "dev": true,
       "requires": {
-        "debug": "~3.1.0",
-        "engine.io": "~3.2.0",
-        "has-binary2": "~1.0.2",
-        "socket.io-adapter": "~1.1.0",
+        "debug": "3.1.0",
+        "engine.io": "3.2.0",
+        "has-binary2": "1.0.3",
+        "socket.io-adapter": "1.1.1",
         "socket.io-client": "2.1.1",
-        "socket.io-parser": "~3.2.0"
+        "socket.io-parser": "3.2.0"
       },
       "dependencies": {
         "debug": {
@@ -15579,14 +15579,14 @@
           "requires": {
             "component-emitter": "1.2.1",
             "component-inherit": "0.0.3",
-            "debug": "~3.1.0",
-            "engine.io-parser": "~2.1.1",
+            "debug": "3.1.0",
+            "engine.io-parser": "2.1.2",
             "has-cors": "1.1.0",
             "indexof": "0.0.1",
             "parseqs": "0.0.5",
             "parseuri": "0.0.5",
-            "ws": "~3.3.1",
-            "xmlhttprequest-ssl": "~1.5.4",
+            "ws": "3.3.3",
+            "xmlhttprequest-ssl": "1.5.5",
             "yeast": "0.1.2"
           }
         },
@@ -15600,15 +15600,15 @@
             "base64-arraybuffer": "0.1.5",
             "component-bind": "1.0.0",
             "component-emitter": "1.2.1",
-            "debug": "~3.1.0",
-            "engine.io-client": "~3.2.0",
-            "has-binary2": "~1.0.2",
+            "debug": "3.1.0",
+            "engine.io-client": "3.2.1",
+            "has-binary2": "1.0.3",
             "has-cors": "1.1.0",
             "indexof": "0.0.1",
             "object-component": "0.0.3",
             "parseqs": "0.0.5",
             "parseuri": "0.0.5",
-            "socket.io-parser": "~3.2.0",
+            "socket.io-parser": "3.2.0",
             "to-array": "0.1.4"
           }
         },
@@ -15619,7 +15619,7 @@
           "dev": true,
           "requires": {
             "component-emitter": "1.2.1",
-            "debug": "~3.1.0",
+            "debug": "3.1.0",
             "isarray": "2.0.1"
           }
         }
@@ -15641,14 +15641,14 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~2.6.4",
-        "engine.io-client": "~3.1.0",
+        "debug": "2.6.9",
+        "engine.io-client": "3.1.6",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "~3.1.1",
+        "socket.io-parser": "3.1.3",
         "to-array": "0.1.4"
       }
     },
@@ -15659,8 +15659,8 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "has-binary2": "~1.0.2",
+        "debug": "3.1.0",
+        "has-binary2": "1.0.3",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -15681,13 +15681,13 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       }
     },
     "sortablejs": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.8.1.tgz",
-      "integrity": "sha512-r0bKxZYGUFgv/6DQSWW8TVJBBtupUn6TPnDABd4rlqNq+u94ct5+barZmYauPAQNCKwy56C1kg9Y9msAN7UPag=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.7.0.tgz",
+      "integrity": "sha1-gKKyNwq9Vo4c7IwnETHvMKkE+ig="
     },
     "source-map": {
       "version": "0.6.1",
@@ -15701,11 +15701,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.2",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -15714,7 +15714,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -15743,8 +15743,8 @@
       "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.4.7",
-        "os-shim": "^0.1.2"
+        "concat-stream": "1.6.2",
+        "os-shim": "0.1.3"
       }
     },
     "spdx-correct": {
@@ -15753,8 +15753,8 @@
       "integrity": "sha512-hxSPZbRZvSDuOvADntOElzJpenIR7wXJkuoUcUtS0erbgt2fgeaoPIYretfKpslMhfFDY4k0MZ2F5CUzhBsSvQ==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.1"
       }
     },
     "spdx-exceptions": {
@@ -15769,8 +15769,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.2.0",
+        "spdx-license-ids": "3.0.1"
       }
     },
     "spdx-license-ids": {
@@ -15797,7 +15797,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -15812,15 +15812,15 @@
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "stable": {
@@ -15847,8 +15847,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -15857,7 +15857,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -15892,8 +15892,8 @@
       "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
       "dev": true,
       "requires": {
-        "commander": "^2.2.0",
-        "limiter": "^1.0.5"
+        "commander": "2.18.0",
+        "limiter": "1.1.3"
       }
     },
     "strict-uri-encode": {
@@ -15908,9 +15908,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -15919,7 +15919,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringify-entities": {
@@ -15928,19 +15928,19 @@
       "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
       "dev": true,
       "requires": {
-        "character-entities-html4": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
+        "character-entities-html4": "1.1.2",
+        "character-entities-legacy": "1.1.2",
+        "is-alphanumerical": "1.0.2",
+        "is-hexadecimal": "1.0.2"
       }
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -15949,7 +15949,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-bom-stream": {
@@ -15958,8 +15958,8 @@
       "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "first-chunk-stream": "2.0.0",
+        "strip-bom": "2.0.0"
       }
     },
     "strip-bom-string": {
@@ -15980,7 +15980,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "strip-json-comments": {
@@ -15995,7 +15995,7 @@
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "strip-url-auth": {
@@ -16016,9 +16016,9 @@
       "integrity": "sha512-TK5zEPeD9NyC1uPIdjikzsgWxdQQN/ry1X3d1iOz1UkYDCmcr928gWD1KHgyC27F50UnE0xCTrBOO1l6KR8M4w==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.0.0",
-        "postcss": "^7.0.0",
-        "postcss-selector-parser": "^3.0.0"
+        "browserslist": "4.4.1",
+        "postcss": "7.0.14",
+        "postcss-selector-parser": "3.1.1"
       },
       "dependencies": {
         "browserslist": {
@@ -16027,9 +16027,9 @@
           "integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000929",
-            "electron-to-chromium": "^1.3.103",
-            "node-releases": "^1.1.3"
+            "caniuse-lite": "1.0.30000933",
+            "electron-to-chromium": "1.3.110",
+            "node-releases": "1.1.6"
           }
         },
         "caniuse-lite": {
@@ -16044,9 +16044,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16055,7 +16055,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16072,9 +16072,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "postcss-selector-parser": {
@@ -16083,9 +16083,9 @@
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
-            "dot-prop": "^4.1.1",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "dot-prop": "4.2.0",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         },
         "supports-color": {
@@ -16094,7 +16094,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16105,53 +16105,53 @@
       "integrity": "sha512-9UiHxZhOAHEgeQ7oLGwrwoDR8vclBKlSX7r4fH0iuu0SfPwFaLkb1c7Q2j1cqg9P7IDXeAV2TvQML/fRQzGBBQ==",
       "dev": true,
       "requires": {
-        "autoprefixer": "^9.0.0",
-        "balanced-match": "^1.0.0",
-        "chalk": "^2.4.1",
-        "cosmiconfig": "^5.0.0",
-        "debug": "^4.0.0",
-        "execall": "^1.0.0",
-        "file-entry-cache": "^4.0.0",
-        "get-stdin": "^6.0.0",
-        "global-modules": "^2.0.0",
-        "globby": "^9.0.0",
-        "globjoin": "^0.1.4",
-        "html-tags": "^2.0.0",
-        "ignore": "^5.0.4",
-        "import-lazy": "^3.1.0",
-        "imurmurhash": "^0.1.4",
-        "known-css-properties": "^0.11.0",
-        "leven": "^2.1.0",
-        "lodash": "^4.17.4",
-        "log-symbols": "^2.0.0",
-        "mathml-tag-names": "^2.0.1",
-        "meow": "^5.0.0",
-        "micromatch": "^3.1.10",
-        "normalize-selector": "^0.2.0",
-        "pify": "^4.0.0",
-        "postcss": "^7.0.13",
-        "postcss-html": "^0.36.0",
-        "postcss-jsx": "^0.36.0",
-        "postcss-less": "^3.1.0",
-        "postcss-markdown": "^0.36.0",
-        "postcss-media-query-parser": "^0.2.3",
-        "postcss-reporter": "^6.0.0",
-        "postcss-resolve-nested-selector": "^0.1.1",
-        "postcss-safe-parser": "^4.0.0",
-        "postcss-sass": "^0.3.5",
-        "postcss-scss": "^2.0.0",
-        "postcss-selector-parser": "^3.1.0",
-        "postcss-syntax": "^0.36.2",
-        "postcss-value-parser": "^3.3.0",
-        "resolve-from": "^4.0.0",
-        "signal-exit": "^3.0.2",
-        "slash": "^2.0.0",
-        "specificity": "^0.4.1",
-        "string-width": "^3.0.0",
-        "style-search": "^0.1.0",
-        "sugarss": "^2.0.0",
-        "svg-tags": "^1.0.0",
-        "table": "^5.0.0"
+        "autoprefixer": "9.4.7",
+        "balanced-match": "1.0.0",
+        "chalk": "2.4.1",
+        "cosmiconfig": "5.0.7",
+        "debug": "4.1.1",
+        "execall": "1.0.0",
+        "file-entry-cache": "4.0.0",
+        "get-stdin": "6.0.0",
+        "global-modules": "2.0.0",
+        "globby": "9.0.0",
+        "globjoin": "0.1.4",
+        "html-tags": "2.0.0",
+        "ignore": "5.0.5",
+        "import-lazy": "3.1.0",
+        "imurmurhash": "0.1.4",
+        "known-css-properties": "0.11.0",
+        "leven": "2.1.0",
+        "lodash": "4.17.11",
+        "log-symbols": "2.2.0",
+        "mathml-tag-names": "2.1.0",
+        "meow": "5.0.0",
+        "micromatch": "3.1.10",
+        "normalize-selector": "0.2.0",
+        "pify": "4.0.1",
+        "postcss": "7.0.14",
+        "postcss-html": "0.36.0",
+        "postcss-jsx": "0.36.0",
+        "postcss-less": "3.1.2",
+        "postcss-markdown": "0.36.0",
+        "postcss-media-query-parser": "0.2.3",
+        "postcss-reporter": "6.0.1",
+        "postcss-resolve-nested-selector": "0.1.1",
+        "postcss-safe-parser": "4.0.1",
+        "postcss-sass": "0.3.5",
+        "postcss-scss": "2.0.0",
+        "postcss-selector-parser": "3.1.1",
+        "postcss-syntax": "0.36.2",
+        "postcss-value-parser": "3.3.0",
+        "resolve-from": "4.0.0",
+        "signal-exit": "3.0.2",
+        "slash": "2.0.0",
+        "specificity": "0.4.1",
+        "string-width": "3.0.0",
+        "style-search": "0.1.0",
+        "sugarss": "2.0.0",
+        "svg-tags": "1.0.0",
+        "table": "5.2.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -16178,16 +16178,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -16196,7 +16196,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -16213,9 +16213,9 @@
           "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
           }
         },
         "debug": {
@@ -16224,7 +16224,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "expand-brackets": {
@@ -16233,13 +16233,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "debug": {
@@ -16257,7 +16257,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -16266,7 +16266,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -16275,7 +16275,7 @@
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -16284,7 +16284,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -16295,7 +16295,7 @@
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -16304,7 +16304,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -16315,9 +16315,9 @@
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
               }
             },
             "kind-of": {
@@ -16340,14 +16340,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -16356,7 +16356,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -16365,7 +16365,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -16376,7 +16376,7 @@
           "integrity": "sha512-AVSwsnbV8vH/UVbvgEhf3saVQXORNv0ZzSkvkhQIaia5Tia+JhGTaa/ePUSVoPHQyGayQNmYfkzFi3WZV5zcpA==",
           "dev": true,
           "requires": {
-            "flat-cache": "^2.0.1"
+            "flat-cache": "2.0.1"
           }
         },
         "fill-range": {
@@ -16385,10 +16385,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -16397,7 +16397,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -16408,7 +16408,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "flat-cache": {
@@ -16417,7 +16417,7 @@
           "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
           "dev": true,
           "requires": {
-            "flatted": "^2.0.0",
+            "flatted": "2.0.0",
             "rimraf": "2.6.3",
             "write": "1.0.3"
           }
@@ -16434,7 +16434,7 @@
           "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
           "dev": true,
           "requires": {
-            "global-prefix": "^3.0.0"
+            "global-prefix": "3.0.0"
           }
         },
         "global-prefix": {
@@ -16443,9 +16443,9 @@
           "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
           "dev": true,
           "requires": {
-            "ini": "^1.3.5",
-            "kind-of": "^6.0.2",
-            "which": "^1.3.1"
+            "ini": "1.3.5",
+            "kind-of": "6.0.2",
+            "which": "1.3.1"
           }
         },
         "globby": {
@@ -16454,13 +16454,13 @@
           "integrity": "sha512-q0qiO/p1w/yJ0hk8V9x1UXlgsXUxlGd0AHUOXZVXBO6aznDtpx7M8D1kBrCAItoPm+4l8r6ATXV1JpjY2SBQOw==",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.2",
-            "dir-glob": "^2.2.1",
-            "fast-glob": "^2.2.6",
-            "glob": "^7.1.3",
-            "ignore": "^4.0.3",
-            "pify": "^4.0.1",
-            "slash": "^2.0.0"
+            "array-union": "1.0.2",
+            "dir-glob": "2.2.2",
+            "fast-glob": "2.2.6",
+            "glob": "7.1.3",
+            "ignore": "4.0.6",
+            "pify": "4.0.1",
+            "slash": "2.0.0"
           },
           "dependencies": {
             "ignore": {
@@ -16495,7 +16495,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -16504,7 +16504,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -16513,9 +16513,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         },
         "is-fullwidth-code-point": {
@@ -16530,7 +16530,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -16539,7 +16539,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -16562,10 +16562,10 @@
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
           },
           "dependencies": {
             "pify": {
@@ -16588,15 +16588,15 @@
           "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
           "dev": true,
           "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0",
-            "yargs-parser": "^10.0.0"
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0",
+            "yargs-parser": "10.1.0"
           }
         },
         "micromatch": {
@@ -16605,19 +16605,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "ms": {
@@ -16632,8 +16632,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "error-ex": "1.3.2",
+            "json-parse-better-errors": "1.0.2"
           }
         },
         "path-type": {
@@ -16642,7 +16642,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           },
           "dependencies": {
             "pify": {
@@ -16665,9 +16665,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           },
           "dependencies": {
             "chalk": {
@@ -16676,9 +16676,9 @@
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.5.0"
               },
               "dependencies": {
                 "supports-color": {
@@ -16687,7 +16687,7 @@
                   "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                   "dev": true,
                   "requires": {
-                    "has-flag": "^3.0.0"
+                    "has-flag": "3.0.0"
                   }
                 }
               }
@@ -16700,9 +16700,9 @@
           "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
           "dev": true,
           "requires": {
-            "dot-prop": "^4.1.1",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "dot-prop": "4.2.0",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         },
         "read-pkg": {
@@ -16711,9 +16711,9 @@
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
           }
         },
         "read-pkg-up": {
@@ -16722,8 +16722,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "redent": {
@@ -16732,8 +16732,8 @@
           "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
           "dev": true,
           "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
           }
         },
         "resolve-from": {
@@ -16754,9 +16754,9 @@
           "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.0.0"
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.0.0"
           }
         },
         "strip-ansi": {
@@ -16765,7 +16765,7 @@
           "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "4.0.0"
           }
         },
         "strip-bom": {
@@ -16786,7 +16786,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "trim-newlines": {
@@ -16801,7 +16801,7 @@
           "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
           "dev": true,
           "requires": {
-            "mkdirp": "^0.5.1"
+            "mkdirp": "0.5.1"
           }
         },
         "yargs-parser": {
@@ -16810,7 +16810,7 @@
           "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -16821,10 +16821,10 @@
       "integrity": "sha512-D7M7tPV7utrGgqCF11E8jqUudt2uWA58jwGnyFlIeaa9bT4kDsZZKjFbGMuY2O9BgiORrGIigI4G5LOx1pDOMw==",
       "dev": true,
       "requires": {
-        "stylelint-media-use-custom-media": "^1.0.0",
-        "stylelint-order": "^1.0.0",
-        "stylelint-use-logical": "^1.1.0",
-        "stylelint-value-no-unknown-custom-properties": "^2.0.0"
+        "stylelint-media-use-custom-media": "1.0.0",
+        "stylelint-order": "1.0.0",
+        "stylelint-use-logical": "1.1.0",
+        "stylelint-value-no-unknown-custom-properties": "2.0.0"
       }
     },
     "stylelint-media-use-custom-media": {
@@ -16839,9 +16839,9 @@
       "integrity": "sha512-2IVM8GzeKIDQDTETNdmgX99ywGrb7OqFWkniCw7QLqS/xONPGMLY/xAQnvGcUS3oBSo8znsoshsWVBqPz2Kv4Q==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10",
-        "postcss": "^7.0.2",
-        "postcss-sorting": "^4.0.0"
+        "lodash": "4.17.11",
+        "postcss": "7.0.14",
+        "postcss-sorting": "4.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -16850,9 +16850,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16861,7 +16861,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16872,9 +16872,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -16883,7 +16883,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16900,7 +16900,7 @@
       "integrity": "sha512-iA7pLNBRCrRi35rUpF3bS4zpPWQtk1YxqKC0MhgOvhI1XDciE/FaAQoFgn65vGMEyQ0Q3PPGfWawn7sVd/thXQ==",
       "dev": true,
       "requires": {
-        "postcss-values-parser": "^2.0.0"
+        "postcss-values-parser": "2.0.1"
       },
       "dependencies": {
         "postcss-values-parser": {
@@ -16909,9 +16909,9 @@
           "integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
           "dev": true,
           "requires": {
-            "flatten": "^1.0.2",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
+            "flatten": "1.0.2",
+            "indexes-of": "1.0.1",
+            "uniq": "1.0.1"
           }
         }
       }
@@ -16922,7 +16922,7 @@
       "integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
       "dev": true,
       "requires": {
-        "postcss": "^7.0.2"
+        "postcss": "7.0.14"
       },
       "dependencies": {
         "chalk": {
@@ -16931,9 +16931,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           },
           "dependencies": {
             "supports-color": {
@@ -16942,7 +16942,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
               }
             }
           }
@@ -16953,9 +16953,9 @@
           "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "chalk": "2.4.2",
+            "source-map": "0.6.1",
+            "supports-color": "6.1.0"
           }
         },
         "supports-color": {
@@ -16964,7 +16964,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -16975,7 +16975,7 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "sver-compat": {
@@ -16984,8 +16984,8 @@
       "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
       "dev": true,
       "requires": {
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "svg-tags": {
@@ -17000,20 +17000,20 @@
       "integrity": "sha512-GBkJbnTuFpM4jFbiERHDWhZc/S/kpHToqmZag3aEBjPYK44JAN2QBjvrGIxLOoCyMZjuFQIfTO2eJd8uwLY/9g==",
       "dev": true,
       "requires": {
-        "coa": "~2.0.1",
-        "colors": "~1.1.2",
-        "css-select": "^2.0.0",
-        "css-select-base-adapter": "~0.1.0",
+        "coa": "2.0.2",
+        "colors": "1.1.2",
+        "css-select": "2.0.0",
+        "css-select-base-adapter": "0.1.0",
         "css-tree": "1.0.0-alpha.28",
-        "css-url-regex": "^1.1.0",
-        "csso": "^3.5.0",
-        "js-yaml": "^3.12.0",
-        "mkdirp": "~0.5.1",
-        "object.values": "^1.0.4",
-        "sax": "~1.2.4",
-        "stable": "~0.1.6",
-        "unquote": "~1.1.1",
-        "util.promisify": "~1.0.0"
+        "css-url-regex": "1.1.0",
+        "csso": "3.5.1",
+        "js-yaml": "3.12.1",
+        "mkdirp": "0.5.1",
+        "object.values": "1.0.4",
+        "sax": "1.2.4",
+        "stable": "0.1.8",
+        "unquote": "1.1.1",
+        "util.promisify": "1.0.0"
       }
     },
     "table": {
@@ -17022,10 +17022,10 @@
       "integrity": "sha512-f8mJmuu9beQEDkKHLzOv4VxVYlU68NpdzjbGPl69i4Hx0sTopJuNxuzJd17iV2h24dAfa93u794OnDA5jqXvfQ==",
       "dev": true,
       "requires": {
-        "ajv": "^6.6.1",
-        "lodash": "^4.17.11",
-        "slice-ansi": "^2.0.0",
-        "string-width": "^2.1.1"
+        "ajv": "6.7.0",
+        "lodash": "4.17.11",
+        "slice-ansi": "2.1.0",
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ajv": {
@@ -17034,10 +17034,10 @@
           "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
           }
         },
         "ansi-regex": {
@@ -17070,8 +17070,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -17080,7 +17080,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -17091,7 +17091,7 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
-        "execa": "^0.7.0"
+        "execa": "0.7.0"
       }
     },
     "text-table": {
@@ -17106,8 +17106,8 @@
       "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "object-path": "^0.9.0"
+        "chalk": "1.1.3",
+        "object-path": "0.9.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -17118,15 +17118,15 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
@@ -17139,7 +17139,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -17149,8 +17149,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "through2-filter": {
@@ -17159,8 +17159,8 @@
       "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
       "dev": true,
       "requires": {
-        "through2": "~2.0.0",
-        "xtend": "~4.0.0"
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "time-stamp": {
@@ -17181,8 +17181,8 @@
       "integrity": "sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
       "dev": true,
       "requires": {
-        "es5-ext": "~0.10.14",
-        "next-tick": "1"
+        "es5-ext": "0.10.46",
+        "next-tick": "1.0.0"
       }
     },
     "timsort": {
@@ -17197,7 +17197,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-absolute-glob": {
@@ -17206,8 +17206,8 @@
       "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
       "dev": true,
       "requires": {
-        "is-absolute": "^1.0.0",
-        "is-negated-glob": "^1.0.0"
+        "is-absolute": "1.0.0",
+        "is-negated-glob": "1.0.0"
       }
     },
     "to-array": {
@@ -17228,7 +17228,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "to-regex": {
@@ -17237,10 +17237,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -17249,8 +17249,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       },
       "dependencies": {
         "is-number": {
@@ -17259,7 +17259,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         }
       }
@@ -17270,7 +17270,7 @@
       "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
       "dev": true,
       "requires": {
-        "through2": "^2.0.3"
+        "through2": "2.0.3"
       }
     },
     "tough-cookie": {
@@ -17279,8 +17279,8 @@
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
+        "psl": "1.1.29",
+        "punycode": "1.4.1"
       }
     },
     "trim": {
@@ -17301,7 +17301,7 @@
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "trim-right": {
@@ -17334,7 +17334,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -17350,7 +17350,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "typedarray": {
@@ -17371,8 +17371,8 @@
       "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
       "dev": true,
       "requires": {
-        "commander": "~2.17.1",
-        "source-map": "~0.6.1"
+        "commander": "2.17.1",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "commander": {
@@ -17407,15 +17407,15 @@
       "integrity": "sha1-M52kZGJS0ILcN45wgGcpl1DhG0k=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1",
-        "arr-map": "^2.0.0",
-        "bach": "^1.0.0",
-        "collection-map": "^1.0.0",
-        "es6-weak-map": "^2.0.1",
-        "last-run": "^1.1.0",
-        "object.defaults": "^1.0.0",
-        "object.reduce": "^1.0.0",
-        "undertaker-registry": "^1.0.0"
+        "arr-flatten": "1.1.0",
+        "arr-map": "2.0.2",
+        "bach": "1.2.0",
+        "collection-map": "1.0.0",
+        "es6-weak-map": "2.0.2",
+        "last-run": "1.1.1",
+        "object.defaults": "1.1.0",
+        "object.reduce": "1.0.1",
+        "undertaker-registry": "1.0.1"
       }
     },
     "undertaker-registry": {
@@ -17430,8 +17430,8 @@
       "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "xtend": "^4.0.1"
+        "inherits": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "unified": {
@@ -17440,14 +17440,14 @@
       "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
       "dev": true,
       "requires": {
-        "@types/unist": "^2.0.0",
-        "@types/vfile": "^3.0.0",
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "trough": "^1.0.0",
-        "vfile": "^3.0.0",
-        "x-is-string": "^0.1.0"
+        "@types/unist": "2.0.2",
+        "@types/vfile": "3.0.2",
+        "bail": "1.0.3",
+        "extend": "3.0.2",
+        "is-plain-obj": "1.1.0",
+        "trough": "1.0.3",
+        "vfile": "3.0.1",
+        "x-is-string": "0.1.0"
       }
     },
     "union-value": {
@@ -17456,10 +17456,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -17468,7 +17468,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -17477,10 +17477,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -17503,8 +17503,8 @@
       "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
       "dev": true,
       "requires": {
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "through2-filter": "^3.0.0"
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "through2-filter": "3.0.0"
       }
     },
     "unique-string": {
@@ -17513,7 +17513,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "^1.0.0"
+        "crypto-random-string": "1.0.0"
       }
     },
     "unist-util-find-all-after": {
@@ -17522,7 +17522,7 @@
       "integrity": "sha512-nDl79mKpffXojLpCimVXnxhlH/jjaTnDuScznU9J4jjsaUtBdDbxmlc109XtcqxY4SDO0SwzngsxxW8DIISt1w==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^2.0.0"
+        "unist-util-is": "2.1.2"
       }
     },
     "unist-util-is": {
@@ -17537,7 +17537,7 @@
       "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
       "dev": true,
       "requires": {
-        "unist-util-visit": "^1.1.0"
+        "unist-util-visit": "1.4.0"
       }
     },
     "unist-util-stringify-position": {
@@ -17552,7 +17552,7 @@
       "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
       "dev": true,
       "requires": {
-        "unist-util-visit-parents": "^2.0.0"
+        "unist-util-visit-parents": "2.0.1"
       }
     },
     "unist-util-visit-parents": {
@@ -17561,7 +17561,7 @@
       "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^2.1.2"
+        "unist-util-is": "2.1.2"
       }
     },
     "units-css": {
@@ -17570,8 +17570,8 @@
       "integrity": "sha1-1iKGU6UZg9fBb/KPi53Dsf/tOgc=",
       "dev": true,
       "requires": {
-        "isnumeric": "^0.2.0",
-        "viewport-dimensions": "^0.2.0"
+        "isnumeric": "0.2.0",
+        "viewport-dimensions": "0.2.0"
       }
     },
     "universalify": {
@@ -17598,8 +17598,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -17608,9 +17608,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -17662,16 +17662,16 @@
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "dev": true,
       "requires": {
-        "boxen": "^1.2.1",
-        "chalk": "^2.0.1",
-        "configstore": "^3.0.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^1.0.10",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "boxen": "1.3.0",
+        "chalk": "2.4.1",
+        "configstore": "3.1.2",
+        "import-lazy": "2.1.0",
+        "is-ci": "1.2.1",
+        "is-installed-globally": "0.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "uri-js": {
@@ -17680,7 +17680,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       },
       "dependencies": {
         "punycode": {
@@ -17703,7 +17703,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "1.0.4"
       }
     },
     "use": {
@@ -17730,8 +17730,8 @@
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
+        "define-properties": "1.1.3",
+        "object.getownpropertydescriptors": "2.0.3"
       }
     },
     "utils-merge": {
@@ -17752,7 +17752,7 @@
       "integrity": "sha512-MtivA7GF24yMPte9Rp/BWGCYQNaUj86zeYxV/x2RRJMKagImbbv3u8iJC57lNhWLPcGLJmHcHmFWkNsplbbLWw==",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "validate-npm-package-license": {
@@ -17761,8 +17761,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.0.1",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "value-or-function": {
@@ -17783,9 +17783,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vfile": {
@@ -17794,10 +17794,10 @@
       "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
       "dev": true,
       "requires": {
-        "is-buffer": "^2.0.0",
+        "is-buffer": "2.0.3",
         "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
+        "unist-util-stringify-position": "1.1.2",
+        "vfile-message": "1.1.1"
       },
       "dependencies": {
         "is-buffer": {
@@ -17826,7 +17826,7 @@
       "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
       "dev": true,
       "requires": {
-        "unist-util-stringify-position": "^1.1.1"
+        "unist-util-stringify-position": "1.1.2"
       }
     },
     "viewport-dimensions": {
@@ -17841,8 +17841,8 @@
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.0",
-        "clone-stats": "^0.0.1",
+        "clone": "1.0.4",
+        "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
       }
     },
@@ -17852,8 +17852,8 @@
       "integrity": "sha1-lsGjR5uMU5JULGEgKQE7Wyf4i78=",
       "dev": true,
       "requires": {
-        "bl": "^1.2.1",
-        "through2": "^2.0.3"
+        "bl": "1.2.2",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "bl": {
@@ -17862,8 +17862,8 @@
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
+            "readable-stream": "2.3.6",
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -17874,12 +17874,12 @@
       "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.3.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0",
-        "strip-bom-stream": "^2.0.0",
-        "vinyl": "^1.1.0"
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0",
+        "strip-bom-stream": "2.0.0",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "vinyl": {
@@ -17888,8 +17888,8 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -17901,23 +17901,23 @@
       "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
       "dev": true,
       "requires": {
-        "fs-mkdirp-stream": "^1.0.0",
-        "glob-stream": "^6.1.0",
-        "graceful-fs": "^4.0.0",
-        "is-valid-glob": "^1.0.0",
-        "lazystream": "^1.0.0",
-        "lead": "^1.0.0",
-        "object.assign": "^4.0.4",
-        "pumpify": "^1.3.5",
-        "readable-stream": "^2.3.3",
-        "remove-bom-buffer": "^3.0.0",
-        "remove-bom-stream": "^1.2.0",
-        "resolve-options": "^1.1.0",
-        "through2": "^2.0.0",
-        "to-through": "^2.0.0",
-        "value-or-function": "^3.0.0",
-        "vinyl": "^2.0.0",
-        "vinyl-sourcemap": "^1.1.0"
+        "fs-mkdirp-stream": "1.0.0",
+        "glob-stream": "6.1.0",
+        "graceful-fs": "4.1.11",
+        "is-valid-glob": "1.0.0",
+        "lazystream": "1.0.0",
+        "lead": "1.0.0",
+        "object.assign": "4.1.0",
+        "pumpify": "1.5.1",
+        "readable-stream": "2.3.6",
+        "remove-bom-buffer": "3.0.0",
+        "remove-bom-stream": "1.2.0",
+        "resolve-options": "1.1.0",
+        "through2": "2.0.3",
+        "to-through": "2.0.0",
+        "value-or-function": "3.0.0",
+        "vinyl": "2.2.0",
+        "vinyl-sourcemap": "1.1.0"
       },
       "dependencies": {
         "clone": {
@@ -17944,12 +17944,12 @@
           "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.2",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.2",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -17960,8 +17960,8 @@
       "integrity": "sha1-84pa+53R6Ttl1VBGmsYYKsT1S44=",
       "dev": true,
       "requires": {
-        "through2": "^2.0.3",
-        "vinyl": "^2.1.0"
+        "through2": "2.0.3",
+        "vinyl": "2.2.0"
       },
       "dependencies": {
         "clone": {
@@ -17988,12 +17988,12 @@
           "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.2",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.2",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -18004,13 +18004,13 @@
       "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
       "dev": true,
       "requires": {
-        "append-buffer": "^1.0.2",
-        "convert-source-map": "^1.5.0",
-        "graceful-fs": "^4.1.6",
-        "normalize-path": "^2.1.1",
-        "now-and-later": "^2.0.0",
-        "remove-bom-buffer": "^3.0.0",
-        "vinyl": "^2.0.0"
+        "append-buffer": "1.0.2",
+        "convert-source-map": "1.6.0",
+        "graceful-fs": "4.1.11",
+        "normalize-path": "2.1.1",
+        "now-and-later": "2.0.0",
+        "remove-bom-buffer": "3.0.0",
+        "vinyl": "2.2.0"
       },
       "dependencies": {
         "clone": {
@@ -18037,12 +18037,12 @@
           "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.2",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.2",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -18053,7 +18053,7 @@
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.1"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -18082,7 +18082,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -18097,7 +18097,7 @@
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -18118,8 +18118,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -18128,7 +18128,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -18147,12 +18147,12 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       }
     },
     "wrappy": {
@@ -18167,7 +18167,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "write-file-atomic": {
@@ -18176,9 +18176,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "ws": {
@@ -18187,9 +18187,9 @@
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "dev": true,
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.2",
+        "ultron": "1.1.1"
       }
     },
     "x-is-string": {
@@ -18210,7 +18210,7 @@
       "integrity": "sha512-ruPC/fyPNck2BD1dpz0AZZyrEwMOrWTO5lDdIXS91rs3wtm4j+T8Rp2o+zoOYkkAxJTZRPOSnOGei1egoRmKMQ==",
       "dev": true,
       "requires": {
-        "sax": "^1.2.1"
+        "sax": "1.2.4"
       }
     },
     "xmlhttprequest-ssl": {
@@ -18239,24 +18239,24 @@
     },
     "yargs": {
       "version": "6.4.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
       "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
       "dev": true,
       "requires": {
-        "camelcase": "^3.0.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.2",
-        "which-module": "^1.0.0",
-        "window-size": "^0.2.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^4.1.0"
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "window-size": "0.2.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "4.2.1"
       }
     },
     "yargs-parser": {
@@ -18265,7 +18265,7 @@
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "dev": true,
       "requires": {
-        "camelcase": "^3.0.0"
+        "camelcase": "3.0.0"
       }
     },
     "yeast": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:js": "eslint src/**/*.js --cache --ignore-pattern .gitignore"
   },
   "dependencies": {
-    "sortablejs": "^1.8.1"
+    "sortablejs": "1.7.0"
   },
   "devDependencies": {
     "autoprefixer": "^9.4.7",


### PR DESCRIPTION
@dlewis-esri I think the module version might have gotten accidentally bumped up on a previous commit.