### PR TITLE
Make any text used in scrim for a11y be invisible

### DIFF
--- a/src/header/css/header.pcss
+++ b/src/header/css/header.pcss
@@ -3,48 +3,48 @@
 /* Global Header
 /* ========================================================================== */
 .esri-header-wrap {
- background: var(--mono-100);
- box-shadow: 0 1px 0 0 var(--mono-88);
- position: relative;
- z-index: 101;
+	background: var(--mono-100);
+	box-shadow: 0 1px 0 0 var(--mono-88);
+	position: relative;
+	z-index: 101;
 }
 
 .esri-header {
- align-items: center;
- color: var(--mono-35) var(--mono-100);
- cursor: default;
- display: flex;
- justify-content: space-between;
- user-select: none;
- height: var(--header-height);
- &.-web {
-         width: 1440px;
-         max-width: 96vw;
-         margin: 0 auto;
+	align-items: center;
+	color: var(--mono-35) var(--mono-100);
+	cursor: default;
+	display: flex;
+	justify-content: space-between;
+	user-select: none;
+	height: var(--header-height);
+	&.-web {
+		width: 1440px;
+		max-width: 96vw;
+		margin: 0 auto;
 
-         &.-always-hamburger {
-                 width: 100%;
-                 max-width: 100vw;
-         }
+		&.-always-hamburger {
+			width: 100%;
+			max-width: 100vw;
+		}
 
-         @media (--width-sm) {
-                 padding-left: 0;
-                 padding-right: 0;
-                 max-width: 100%;
-         }
- }
+		@media (--width-sm) {
+			padding-left: 0;
+			padding-right: 0;
+			max-width: 100%;
+		}
+	}
 
- &, & * {
-         box-sizing: border-box;
- }
+	&, & * {
+		box-sizing: border-box;
+	}
 
- & li, & label {
-         margin: 0;
- }
+	& li, & label {
+		margin: 0;
+	}
 
- & input {
-         height: initial
- }
+	& input {
+		height: initial
+	}
 }
 
 .esri-header .hidden{
@@ -55,56 +55,56 @@
 /* ========================================================================== */
 
 .esri-header-canvas {
- color: rgba(0,0,0,0);
- border-style: none;
- content: "";
- inset-block-end: 0;
- inset-inline: 0;
- padding: 0;
- position: absolute;
- size: 100%;
- height: 100vh;
- -webkit-tap-highlight-color: transparent;
- transition: opacity var(--fast-speed) ease-in-out, visibility 0ms var(--fast-speed);
- z-index: -1;
- inset-block-start: var(--header-height);
+	color: rgba(0,0,0,0)
+	border-style: none;
+	content: "";
+	inset-block-end: 0;
+	inset-inline: 0;
+	padding: 0;
+	position: absolute;
+	size: 100%;
+	height: 100vh;
+	-webkit-tap-highlight-color: transparent;
+	transition: opacity var(--fast-speed) ease-in-out, visibility 0ms var(--fast-speed);
+	z-index: -1;
+	inset-block-start: var(--header-height);
 
- &[data-open="false"] {
-         opacity: 0;
-         visibility: hidden;
- }
+	&[data-open="false"] {
+		opacity: 0;
+		visibility: hidden;
+	}
 
- &[data-open="true"] {
-         opacity: 1;
-         transition: opacity var(--fast-speed) ease-in-out;
- }
+	&[data-open="true"] {
+		opacity: 1;
+		transition: opacity var(--fast-speed) ease-in-out;
+	}
 
- &[data-state="menu"] {
-         background-color: color(var(--mono-0) a(50%));
- }
+	&[data-state="menu"] {
+		background-color: color(var(--mono-0) a(50%));
+	}
 
- &[data-state="search"] {
-         background-color: color(var(--mono-97) a(98%));
-         box-shadow: inset 0 1px 0 0 var(--mono-88);
- }
+	&[data-state="search"] {
+		background-color: color(var(--mono-97) a(98%));
+		box-shadow: inset 0 1px 0 0 var(--mono-88);
+	}
 }
 
 .-app .esri-header-canvas {
-         inset-block-start: calc(var(--header-height) + 3px);
+		inset-block-start: calc(var(--header-height) + 3px);
 }
 
 /* Global Header: Barrier
 /* ========================================================================== */
 
 .esri-header-barrier {
- height: var(--header-height);
+	height: var(--header-height);
 }
 
 /* Global Header: "Is Open" (used to fix scrolling when the menu is open)
 /* ========================================================================== */
 
 [data-header-is-open] {
- position: fixed;
- size: 100vw 100vh;
- size: var(--esri-vw) var(--esri-vh);
+	position: fixed;
+	size: 100vw 100vh;
+	size: var(--esri-vw) var(--esri-vh);
 }

--- a/src/header/css/header.pcss
+++ b/src/header/css/header.pcss
@@ -3,48 +3,48 @@
 /* Global Header
 /* ========================================================================== */
 .esri-header-wrap {
-	background: var(--mono-100);
-	box-shadow: 0 1px 0 0 var(--mono-88);
-	position: relative;
-	z-index: 101;
+ background: var(--mono-100);
+ box-shadow: 0 1px 0 0 var(--mono-88);
+ position: relative;
+ z-index: 101;
 }
 
 .esri-header {
-	align-items: center;
-	color: var(--mono-35) var(--mono-100);
-	cursor: default;
-	display: flex;
-	justify-content: space-between;
-	user-select: none;
-	height: var(--header-height);
-	&.-web {
-		width: 1440px;
-		max-width: 96vw;
-		margin: 0 auto;
+ align-items: center;
+ color: var(--mono-35) var(--mono-100);
+ cursor: default;
+ display: flex;
+ justify-content: space-between;
+ user-select: none;
+ height: var(--header-height);
+ &.-web {
+         width: 1440px;
+         max-width: 96vw;
+         margin: 0 auto;
 
-		&.-always-hamburger {
-			width: 100%;
-			max-width: 100vw;
-		}
+         &.-always-hamburger {
+                 width: 100%;
+                 max-width: 100vw;
+         }
 
-		@media (--width-sm) {
-			padding-left: 0;
-			padding-right: 0;
-			max-width: 100%;
-		}
-	}
+         @media (--width-sm) {
+                 padding-left: 0;
+                 padding-right: 0;
+                 max-width: 100%;
+         }
+ }
 
-	&, & * {
-		box-sizing: border-box;
-	}
+ &, & * {
+         box-sizing: border-box;
+ }
 
-	& li, & label {
-		margin: 0;
-	}
+ & li, & label {
+         margin: 0;
+ }
 
-	& input {
-		height: initial
-	}
+ & input {
+         height: initial
+ }
 }
 
 .esri-header .hidden{
@@ -55,55 +55,56 @@
 /* ========================================================================== */
 
 .esri-header-canvas {
-	border-style: none;
-	content: "";
-	inset-block-end: 0;
-	inset-inline: 0;
-	padding: 0;
-	position: absolute;
-	size: 100%;
-	height: 100vh;
-	-webkit-tap-highlight-color: transparent;
-	transition: opacity var(--fast-speed) ease-in-out, visibility 0ms var(--fast-speed);
-	z-index: -1;
-	inset-block-start: var(--header-height);
+ color: rgba(0,0,0,0);
+ border-style: none;
+ content: "";
+ inset-block-end: 0;
+ inset-inline: 0;
+ padding: 0;
+ position: absolute;
+ size: 100%;
+ height: 100vh;
+ -webkit-tap-highlight-color: transparent;
+ transition: opacity var(--fast-speed) ease-in-out, visibility 0ms var(--fast-speed);
+ z-index: -1;
+ inset-block-start: var(--header-height);
 
-	&[data-open="false"] {
-		opacity: 0;
-		visibility: hidden;
-	}
+ &[data-open="false"] {
+         opacity: 0;
+         visibility: hidden;
+ }
 
-	&[data-open="true"] {
-		opacity: 1;
-		transition: opacity var(--fast-speed) ease-in-out;
-	}
+ &[data-open="true"] {
+         opacity: 1;
+         transition: opacity var(--fast-speed) ease-in-out;
+ }
 
-	&[data-state="menu"] {
-		background-color: color(var(--mono-0) a(50%));
-	}
+ &[data-state="menu"] {
+         background-color: color(var(--mono-0) a(50%));
+ }
 
-	&[data-state="search"] {
-		background-color: color(var(--mono-97) a(98%));
-		box-shadow: inset 0 1px 0 0 var(--mono-88);
-	}
+ &[data-state="search"] {
+         background-color: color(var(--mono-97) a(98%));
+         box-shadow: inset 0 1px 0 0 var(--mono-88);
+ }
 }
 
 .-app .esri-header-canvas {
-		inset-block-start: calc(var(--header-height) + 3px);
+         inset-block-start: calc(var(--header-height) + 3px);
 }
 
 /* Global Header: Barrier
 /* ========================================================================== */
 
 .esri-header-barrier {
-	height: var(--header-height);
+ height: var(--header-height);
 }
 
 /* Global Header: "Is Open" (used to fix scrolling when the menu is open)
 /* ========================================================================== */
 
 [data-header-is-open] {
-	position: fixed;
-	size: 100vw 100vh;
-	size: var(--esri-vw) var(--esri-vh);
+ position: fixed;
+ size: 100vw 100vh;
+ size: var(--esri-vw) var(--esri-vh);
 }


### PR DESCRIPTION
The scrim gets converted to a button by the build process, which leads to the a11y problem that it is a button with empty task (see #304). By adding a bit of text to the div, the a11y problem is resolved, but the text is now appearing (it didn't when #304 was created). By making the scrim's text transparent, we get both a11y acceptance and no visible text.